### PR TITLE
Fix quick install repository URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ backend so you can start running without picking weights out of a long list.
 You will need Rust (stable, 1.75+) and one local-inference backend running.
 
 ```bash
-git clone https://github.com/morganlinton/SmallHarness.git
+git clone https://github.com/GetSmallAI/SmallHarness.git
 cd SmallHarness
 cp .env.example .env
 cargo run --release


### PR DESCRIPTION
Updates the Quick Install clone command to use the current GetSmallAI repo.