### PR TITLE
Add ChatGPT Codex OAuth backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1182,6 +1182,7 @@ dependencies = [
  "chrono",
  "crossterm",
  "futures-util",
+ "getrandom 0.2.17",
  "globset",
  "ignore",
  "regex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1178,6 +1178,7 @@ version = "0.4.13"
 dependencies = [
  "anyhow",
  "async-trait",
+ "base64",
  "chrono",
  "crossterm",
  "futures-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ walkdir = "2"
 ignore = "0.4"
 sha2 = "0.10"
 base64 = "0.22"
+getrandom = "0.2"
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 anyhow = "1"
 tempfile = "3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ globset = "0.4"
 walkdir = "2"
 ignore = "0.4"
 sha2 = "0.10"
+base64 = "0.22"
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 anyhow = "1"
 tempfile = "3"

--- a/README.md
+++ b/README.md
@@ -120,6 +120,21 @@ Prefer not to put the key in your environment? Launch first, then run
 file under `~/.config/small-harness/`. Cost per turn and per session shows
 live on the status line.
 
+### Path A2 — ChatGPT / Codex subscription login
+
+If you want to use a ChatGPT/Codex subscription instead of OpenAI API billing,
+log in with OAuth inside the TUI:
+
+```text
+/login openai-codex
+/backend openai-codex
+```
+
+This is intentionally separate from `/auth set openai`: `openai` uses an
+`OPENAI_API_KEY` and the public OpenAI API, while `openai-codex` stores a
+refreshable ChatGPT OAuth token in `auth.json` and talks to the Codex Responses
+backend.
+
 ### Path B — Local model
 
 *Private, free, offline — runs entirely on your machine.*
@@ -204,11 +219,13 @@ A handful of moves worth knowing right away:
 | `llamacpp` | `http://localhost:8080/v1` | Direct GGUF serving (via `llama-server`) |
 | `openrouter` | `https://openrouter.ai/api/v1` | Cloud A/B with `/compare`; access to frontier models |
 | `openai` | `https://api.openai.com/v1` | Direct provider access with your own key |
+| `openai-codex` | `https://chatgpt.com/backend-api/codex/responses` | ChatGPT/Codex subscription OAuth via `/login openai-codex` |
 
 Switch at runtime with `/backend <name>`. Endpoint overrides:
 `OLLAMA_BASE_URL`, `LM_STUDIO_BASE_URL`, `MLX_BASE_URL`, `LLAMACPP_BASE_URL`,
-`OPENAI_BASE_URL`. Cloud backends require an API key (set via
-[`/auth`](#cost-and-credentials) or env var).
+`OPENAI_BASE_URL`, `OPENAI_CODEX_BASE_URL`. API backends require an API key
+(set via [`/auth`](#cost-and-credentials) or env var); `openai-codex` requires
+`/login openai-codex`.
 
 ### Default model per backend
 
@@ -224,6 +241,7 @@ or `modelOverride` in your config.
 | `llamacpp` | `gpt-3.5-turbo` |
 | `openrouter` | `qwen/qwen-2.5-coder-32b-instruct` |
 | `openai` | `gpt-4o-mini` |
+| `openai-codex` | `gpt-5.5` |
 
 ### Recommend the right model for your box
 
@@ -302,7 +320,9 @@ this exact call`. The session cache resets on `/new`.
 /backend <name>        switch backend
 /model [id]            list / pick a model (shows context + cost when known)
 /tools auto|fixed|<…>  show or set the active tool pool
-/auth                  manage API keys (list, set, clear)
+/auth                  manage API keys and OAuth credentials
+/login openai-codex    sign in with ChatGPT/Codex subscription OAuth
+/logout openai-codex   clear the stored ChatGPT/Codex login
 /image <path>          attach an image to the next user turn
 /reasoning on|off      toggle the streaming reasoning panel
 /verbose on|off        show every tool call with its full args + result
@@ -332,19 +352,26 @@ Run `/help` in the harness for the full list with descriptions.
 
 ## Cost and credentials
 
-### Credentials with `/auth`
+### Credentials with `/auth` and `/login`
 
-Cloud backends authenticate with API keys. Paste them once and Small Harness
-stores them at `~/.config/small-harness/auth.json` (mode `0600`). Environment
-variables always win at lookup time, so CI and scripted users see no change
-in behavior.
+API-key cloud backends authenticate with API keys. Paste them once and Small
+Harness stores them at `~/.config/small-harness/auth.json` (mode `0600`).
+Environment variables always win at lookup time, so CI and scripted users see
+no change in behavior.
 
 ```text
 /auth                    show what's configured (keys are masked)
 /auth set openai         paste your OpenAI key, save to file + this session
 /auth set openrouter     paste your OpenRouter key
 /auth clear openai       remove from the file (env stays for this session)
+/login openai-codex      browser/device-code login with ChatGPT/Codex
+/logout openai-codex     remove the stored OAuth credential
 ```
+
+`openai-codex` is not an `OPENAI_API_KEY` replacement. It uses browser/device
+OAuth, stores `{access, refresh, expires, accountId}` in the same `auth.json`,
+refreshes the access token before use, and sends model traffic to the Codex
+Responses backend.
 
 ### Per-turn and session cost
 
@@ -486,12 +513,13 @@ Resolution order (later overrides earlier):
 ### Environment variables (the useful ones)
 
 ```bash
-BACKEND=ollama                                          # ollama|lm-studio|mlx|llamacpp|openrouter|openai
+BACKEND=ollama                                          # ollama|lm-studio|mlx|llamacpp|openrouter|openai|openai-codex
 AGENT_MODEL=qwen2.5-coder:14b                           # overrides the backend default model
 
 OPENAI_API_KEY=sk-...                                   # required for openai
 OPENROUTER_API_KEY=sk-or-...                            # required for openrouter / /compare
 OPENAI_BASE_URL=https://api.openai.com/v1               # point at a compatible proxy if needed
+OPENAI_CODEX_BASE_URL=https://chatgpt.com/backend-api    # override Codex backend base if needed
 
 APPROVAL_POLICY=always                                  # always | dangerous-only | never
 AGENT_TOOLS=file_read,grep,list_dir,file_edit,file_write,shell,update_plan,task
@@ -591,6 +619,7 @@ runtime.
 - **llama.cpp** — `llama-server -m /path/to/model.gguf --host 127.0.0.1 --port 8080 --jinja` (the `--jinja` flag enables native tool calls).
 - **OpenRouter** — set `OPENROUTER_API_KEY` (or use `/auth set openrouter`).
 - **OpenAI** — set `OPENAI_API_KEY` (or use `/auth set openai`). Use `OPENAI_BASE_URL` for a compatible proxy.
+- **OpenAI Codex** — run `/login openai-codex`, then `/backend openai-codex`.
 
 Run `/doctor --deep` for a fuller capability probe (streaming, usage chunks,
 native tool calls, inline JSON fallback). Reports land under `.sessions/doctor/`.
@@ -669,8 +698,9 @@ Guidelines:
 
 - Mutating tools implement `require_approval` on the `Tool` trait (return
   `true`, or compute from args — see `shell.rs`).
-- New backends need an OpenAI-compatible `/v1/chat/completions` endpoint
-  and a default model in `backends.rs`.
+- New backends usually need an OpenAI-compatible `/v1/chat/completions`
+  endpoint and a default model in `backends.rs`; non-compatible transports
+  should add an adapter like `codex_responses.rs`.
 - Before opening a PR, run the full check suite: `cargo fmt --check`,
   `cargo clippy --all-targets -- -D warnings`, and `cargo test`.
 

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -6,14 +6,46 @@ use std::path::PathBuf;
 
 /// Persistent on-disk credential store.
 ///
-/// File format is `{"<provider>": "<api-key>"}` so users can read or edit it
-/// by hand without a CLI. Env vars always win at lookup time; this file
-/// just hydrates them at startup, so paste-once / use-everywhere works
-/// without leaking secrets into the shell's environment permanently.
+/// Legacy files used `{"<provider>": "<api-key>"}`.  New files may also store
+/// typed entries so OAuth providers (notably `openai-codex`, which uses a
+/// ChatGPT/Codex subscription login rather than an API key) can live beside API
+/// keys without changing existing user config.
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
 pub struct AuthStore {
     #[serde(flatten)]
-    pub keys: BTreeMap<String, String>,
+    pub credentials: BTreeMap<String, StoredCredential>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum StoredCredential {
+    /// Backward-compatible `"sk-..."` value from pre-OAuth auth.json files.
+    LegacyApiKey(String),
+    ApiKey(ApiKeyCredential),
+    OAuth(OAuthCredential),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ApiKeyCredential {
+    #[serde(rename = "type")]
+    pub credential_type: String,
+    pub key: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OAuthCredential {
+    #[serde(rename = "type")]
+    pub credential_type: String,
+    pub access: String,
+    pub refresh: String,
+    /// Unix timestamp in seconds when the access token expires.
+    pub expires: u64,
+    #[serde(
+        rename = "accountId",
+        alias = "account_id",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub account_id: Option<String>,
 }
 
 /// Providers that have a single API-key dimension and a fixed env var.
@@ -86,15 +118,37 @@ impl AuthStore {
     }
 
     pub fn set(&mut self, provider: impl Into<String>, key: impl Into<String>) {
-        self.keys.insert(provider.into(), key.into());
+        self.credentials.insert(
+            provider.into(),
+            StoredCredential::ApiKey(ApiKeyCredential {
+                credential_type: "api_key".into(),
+                key: key.into(),
+            }),
+        );
+    }
+
+    pub fn set_oauth(&mut self, provider: impl Into<String>, credential: OAuthCredential) {
+        self.credentials
+            .insert(provider.into(), StoredCredential::OAuth(credential));
     }
 
     pub fn clear(&mut self, provider: &str) -> bool {
-        self.keys.remove(provider).is_some()
+        self.credentials.remove(provider).is_some()
     }
 
     pub fn get(&self, provider: &str) -> Option<&str> {
-        self.keys.get(provider).map(String::as_str)
+        match self.credentials.get(provider)? {
+            StoredCredential::LegacyApiKey(key) => Some(key.as_str()),
+            StoredCredential::ApiKey(credential) => Some(credential.key.as_str()),
+            StoredCredential::OAuth(_) => None,
+        }
+    }
+
+    pub fn get_oauth(&self, provider: &str) -> Option<&OAuthCredential> {
+        match self.credentials.get(provider)? {
+            StoredCredential::OAuth(credential) => Some(credential),
+            _ => None,
+        }
     }
 }
 
@@ -119,13 +173,15 @@ fn set_secret_permissions(_path: &PathBuf) -> Result<()> {
 /// who already export OPENAI_API_KEY see no change in behavior.
 pub fn hydrate_env_from_file() {
     let store = AuthStore::load();
-    for (provider, key) in &store.keys {
+    for provider in store.credentials.keys() {
         if let Some(env_name) = env_var_for(provider) {
             let already_set = std::env::var(env_name)
                 .map(|v| !v.is_empty())
                 .unwrap_or(false);
             if !already_set {
-                std::env::set_var(env_name, key);
+                if let Some(key) = store.get(provider) {
+                    std::env::set_var(env_name, key);
+                }
             }
         }
     }
@@ -195,6 +251,38 @@ mod tests {
         assert_eq!(loaded.get("openrouter"), Some("sk-or-2"));
     }
 
+    #[test]
+    fn legacy_string_api_keys_still_load() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("auth.json");
+        fs::write(&path, r#"{"openai":"sk-legacy"}"#).unwrap();
+        let loaded = AuthStore::load_from(&path).unwrap();
+        assert_eq!(loaded.get("openai"), Some("sk-legacy"));
+    }
+
+    #[test]
+    fn oauth_credentials_roundtrip() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("auth.json");
+        let mut store = AuthStore::default();
+        store.set_oauth(
+            "openai-codex",
+            OAuthCredential {
+                credential_type: "oauth".into(),
+                access: "access".into(),
+                refresh: "refresh".into(),
+                expires: 123,
+                account_id: Some("acct".into()),
+            },
+        );
+        store.save_to(&path).unwrap();
+        let loaded = AuthStore::load_from(&path).unwrap();
+        let oauth = loaded.get_oauth("openai-codex").unwrap();
+        assert_eq!(oauth.access, "access");
+        assert_eq!(oauth.account_id.as_deref(), Some("acct"));
+        assert_eq!(loaded.get("openai-codex"), None);
+    }
+
     #[cfg(unix)]
     #[test]
     fn saved_file_is_mode_0600() {
@@ -213,7 +301,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("nope.json");
         let store = AuthStore::load_from(&path).unwrap();
-        assert!(store.keys.is_empty());
+        assert!(store.credentials.is_empty());
     }
 
     #[test]

--- a/src/backends.rs
+++ b/src/backends.rs
@@ -10,6 +10,7 @@ pub enum BackendName {
     LlamaCpp,
     Openrouter,
     OpenAi,
+    OpenAiCodex,
 }
 
 impl BackendName {
@@ -21,6 +22,7 @@ impl BackendName {
             BackendName::LlamaCpp => "llamacpp",
             BackendName::Openrouter => "openrouter",
             BackendName::OpenAi => "openai",
+            BackendName::OpenAiCodex => "openai-codex",
         }
     }
     pub fn parse(s: &str) -> Option<Self> {
@@ -31,6 +33,7 @@ impl BackendName {
             "llamacpp" | "llama-cpp" | "llama.cpp" => Some(Self::LlamaCpp),
             "openrouter" => Some(Self::Openrouter),
             "openai" | "open-ai" => Some(Self::OpenAi),
+            "openai-codex" | "open-ai-codex" | "codex" | "chatgpt" => Some(Self::OpenAiCodex),
             _ => None,
         }
     }
@@ -42,6 +45,7 @@ impl BackendName {
             Self::LlamaCpp,
             Self::Openrouter,
             Self::OpenAi,
+            Self::OpenAiCodex,
         ]
     }
     /// True for backends that talk to a process on the user's machine, false
@@ -51,7 +55,7 @@ impl BackendName {
     pub fn is_local(&self) -> bool {
         match self {
             Self::Ollama | Self::LmStudio | Self::Mlx | Self::LlamaCpp => true,
-            Self::Openrouter | Self::OpenAi => false,
+            Self::Openrouter | Self::OpenAi | Self::OpenAiCodex => false,
         }
     }
 }
@@ -109,6 +113,16 @@ pub fn backend(name: BackendName) -> BackendDescriptor {
             api_key: std::env::var("OPENAI_API_KEY").unwrap_or_default(),
             is_local: false,
         },
+        BackendName::OpenAiCodex => BackendDescriptor {
+            name,
+            base_url: std::env::var("OPENAI_CODEX_BASE_URL")
+                .unwrap_or_else(|_| "https://chatgpt.com/backend-api".into()),
+            // OAuth access tokens are loaded/refreshed lazily from auth.json by
+            // the Codex Responses adapter.  Keep this empty so callers don't
+            // accidentally treat ChatGPT subscription auth as an API key.
+            api_key: String::new(),
+            is_local: false,
+        },
     }
 }
 
@@ -118,6 +132,11 @@ pub fn backend(name: BackendName) -> BackendDescriptor {
 /// hardware; bump it with `/model` if you have the headroom.
 pub fn default_model(b: &BackendDescriptor, override_: Option<&str>) -> String {
     if let Some(m) = override_ {
+        if matches!(b.name, BackendName::OpenAiCodex) {
+            return crate::codex_responses::canonical_codex_model(m)
+                .unwrap_or("gpt-5.5")
+                .to_string();
+        }
         return m.to_string();
     }
     match b.name {
@@ -127,6 +146,7 @@ pub fn default_model(b: &BackendDescriptor, override_: Option<&str>) -> String {
         BackendName::LlamaCpp => "gpt-3.5-turbo",
         BackendName::Openrouter => "qwen/qwen-2.5-coder-32b-instruct",
         BackendName::OpenAi => "gpt-4o-mini",
+        BackendName::OpenAiCodex => "gpt-5.5",
     }
     .to_string()
 }
@@ -139,6 +159,15 @@ pub fn validate(b: &BackendDescriptor) -> Result<()> {
     }
     if matches!(b.name, BackendName::OpenAi) && b.api_key.is_empty() {
         return Err(anyhow!("OPENAI_API_KEY is required when BACKEND=openai."));
+    }
+    if matches!(b.name, BackendName::OpenAiCodex)
+        && crate::auth::AuthStore::load()
+            .get_oauth("openai-codex")
+            .is_none()
+    {
+        return Err(anyhow!(
+            "ChatGPT/Codex login is required when BACKEND=openai-codex. Run `/login openai-codex`."
+        ));
     }
     Ok(())
 }
@@ -194,12 +223,50 @@ mod tests {
         assert!(BackendName::LlamaCpp.is_local());
         assert!(!BackendName::Openrouter.is_local());
         assert!(!BackendName::OpenAi.is_local());
+        assert!(!BackendName::OpenAiCodex.is_local());
     }
 
     #[test]
     fn defaults_openai_to_gpt_4o_mini() {
         let model = default_model(&descriptor(BackendName::OpenAi), None);
         assert_eq!(model, "gpt-4o-mini");
+    }
+
+    #[test]
+    fn parses_openai_codex_aliases() {
+        assert_eq!(
+            BackendName::parse("openai-codex"),
+            Some(BackendName::OpenAiCodex)
+        );
+        assert_eq!(BackendName::parse("codex"), Some(BackendName::OpenAiCodex));
+        assert_eq!(
+            BackendName::parse("chatgpt"),
+            Some(BackendName::OpenAiCodex)
+        );
+        assert_eq!(BackendName::OpenAiCodex.as_str(), "openai-codex");
+    }
+
+    #[test]
+    fn lists_openai_codex_as_switchable_backend() {
+        assert!(BackendName::all().contains(&BackendName::OpenAiCodex));
+    }
+
+    #[test]
+    fn defaults_openai_codex_to_codex_model() {
+        let model = default_model(&descriptor(BackendName::OpenAiCodex), None);
+        assert_eq!(model, "gpt-5.5");
+    }
+
+    #[test]
+    fn ignores_non_codex_override_for_openai_codex() {
+        let model = default_model(&descriptor(BackendName::OpenAiCodex), Some("gpt-5-codex"));
+        assert_eq!(model, "gpt-5.5");
+    }
+
+    #[test]
+    fn normalizes_openai_codex_model_aliases() {
+        let model = default_model(&descriptor(BackendName::OpenAiCodex), Some("5.5"));
+        assert_eq!(model, "gpt-5.5");
     }
 
     #[test]

--- a/src/codex_oauth.rs
+++ b/src/codex_oauth.rs
@@ -30,27 +30,16 @@ fn now_secs() -> u64 {
         .unwrap_or(0)
 }
 
+/// Cryptographically-secure random bytes from the OS CSPRNG.
+///
+/// PKCE verifiers and the OAuth `state` nonce MUST be unpredictable, so this
+/// pulls from the platform RNG via `getrandom` (which uses `/dev/urandom` on
+/// Unix, `BCryptGenRandom` on Windows, `getentropy` on macOS, etc.). A failing
+/// OS RNG is a fatal environment problem and unrecoverable here, so we panic
+/// rather than fall back to a weak, predictable seed.
 fn random_bytes<const N: usize>() -> [u8; N] {
     let mut out = [0u8; N];
-    if let Ok(mut file) = std::fs::File::open("/dev/urandom") {
-        if file.read_exact(&mut out).is_ok() {
-            return out;
-        }
-    }
-    // Very small fallback for unusual platforms where /dev/urandom is absent.
-    // OAuth state/PKCE should normally use the OS RNG path above.
-    let seed = format!(
-        "{}:{}:{}",
-        now_secs(),
-        std::process::id(),
-        std::thread::current().name().unwrap_or("small-harness")
-    );
-    let mut digest = Sha256::digest(seed.as_bytes()).to_vec();
-    while digest.len() < N {
-        let next = Sha256::digest(&digest);
-        digest.extend_from_slice(&next);
-    }
-    out.copy_from_slice(&digest[..N]);
+    getrandom::getrandom(&mut out).expect("OS CSPRNG (getrandom) unavailable");
     out
 }
 

--- a/src/codex_oauth.rs
+++ b/src/codex_oauth.rs
@@ -1,0 +1,468 @@
+use anyhow::{anyhow, Context, Result};
+use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
+use serde::Deserialize;
+use serde_json::Value;
+use sha2::{Digest, Sha256};
+use std::io::{Read, Write};
+use std::net::{TcpListener, TcpStream};
+use std::path::PathBuf;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use crate::auth::{auth_file_path, AuthStore, OAuthCredential};
+use crate::input::plain_read_line;
+
+const PROVIDER: &str = "openai-codex";
+const CLIENT_ID: &str = "app_EMoamEEZ73f0CkXaXp7hrann";
+const AUTHORIZE_URL: &str = "https://auth.openai.com/oauth/authorize";
+const TOKEN_URL: &str = "https://auth.openai.com/oauth/token";
+const REDIRECT_URI: &str = "http://localhost:1455/auth/callback";
+const SCOPE: &str = "openid profile email offline_access";
+const DEVICE_USER_CODE_URL: &str = "https://auth.openai.com/api/accounts/deviceauth/usercode";
+const DEVICE_TOKEN_URL: &str = "https://auth.openai.com/api/accounts/deviceauth/token";
+const DEVICE_VERIFICATION_URI: &str = "https://auth.openai.com/codex/device";
+const DEVICE_REDIRECT_URI: &str = "https://auth.openai.com/deviceauth/callback";
+const JWT_CLAIM_PATH: &str = "https://api.openai.com/auth";
+
+fn now_secs() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+fn random_bytes<const N: usize>() -> [u8; N] {
+    let mut out = [0u8; N];
+    if let Ok(mut file) = std::fs::File::open("/dev/urandom") {
+        if file.read_exact(&mut out).is_ok() {
+            return out;
+        }
+    }
+    // Very small fallback for unusual platforms where /dev/urandom is absent.
+    // OAuth state/PKCE should normally use the OS RNG path above.
+    let seed = format!(
+        "{}:{}:{}",
+        now_secs(),
+        std::process::id(),
+        std::thread::current().name().unwrap_or("small-harness")
+    );
+    let mut digest = Sha256::digest(seed.as_bytes()).to_vec();
+    while digest.len() < N {
+        let next = Sha256::digest(&digest);
+        digest.extend_from_slice(&next);
+    }
+    out.copy_from_slice(&digest[..N]);
+    out
+}
+
+fn random_hex(bytes: usize) -> String {
+    random_bytes::<32>()[..bytes]
+        .iter()
+        .map(|b| format!("{b:02x}"))
+        .collect()
+}
+
+fn pkce_pair() -> (String, String) {
+    let verifier = URL_SAFE_NO_PAD.encode(random_bytes::<32>());
+    let challenge = URL_SAFE_NO_PAD.encode(Sha256::digest(verifier.as_bytes()));
+    (verifier, challenge)
+}
+
+fn percent_encode(input: &str) -> String {
+    let mut out = String::new();
+    for b in input.bytes() {
+        match b {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
+                out.push(b as char)
+            }
+            _ => out.push_str(&format!("%{b:02X}")),
+        }
+    }
+    out
+}
+
+fn form_urlencoded(params: &[(&str, &str)]) -> String {
+    params
+        .iter()
+        .map(|(k, v)| format!("{}={}", percent_encode(k), percent_encode(v)))
+        .collect::<Vec<_>>()
+        .join("&")
+}
+
+fn authorization_url(state: &str, challenge: &str) -> String {
+    let params = [
+        ("response_type", "code"),
+        ("client_id", CLIENT_ID),
+        ("redirect_uri", REDIRECT_URI),
+        ("scope", SCOPE),
+        ("code_challenge", challenge),
+        ("code_challenge_method", "S256"),
+        ("state", state),
+        ("id_token_add_organizations", "true"),
+        ("codex_cli_simplified_flow", "true"),
+        ("originator", "small-harness"),
+    ];
+    format!("{AUTHORIZE_URL}?{}", form_urlencoded(&params))
+}
+
+fn query_param(path: &str, name: &str) -> Option<String> {
+    let raw_query = path.split_once('?').map(|(_, q)| q).unwrap_or(path);
+    let query = raw_query
+        .split_once('#')
+        .map(|(q, _)| q)
+        .unwrap_or(raw_query);
+    for pair in query.split('&') {
+        let (k, v) = pair.split_once('=').unwrap_or((pair, ""));
+        if k == name {
+            return Some(percent_decode(v));
+        }
+    }
+    None
+}
+
+fn percent_decode(input: &str) -> String {
+    let mut out = Vec::new();
+    let bytes = input.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'%' && i + 2 < bytes.len() {
+            if let Ok(hex) = std::str::from_utf8(&bytes[i + 1..i + 3]) {
+                if let Ok(value) = u8::from_str_radix(hex, 16) {
+                    out.push(value);
+                    i += 3;
+                    continue;
+                }
+            }
+        }
+        out.push(if bytes[i] == b'+' { b' ' } else { bytes[i] });
+        i += 1;
+    }
+    String::from_utf8_lossy(&out).into_owned()
+}
+
+fn parse_authorization_input(input: &str) -> (Option<String>, Option<String>) {
+    let value = input.trim();
+    if value.contains("code=") || value.contains("state=") {
+        (query_param(value, "code"), query_param(value, "state"))
+    } else if let Some((code, state)) = value.split_once('#') {
+        (Some(code.to_string()), Some(state.to_string()))
+    } else if value.is_empty() {
+        (None, None)
+    } else {
+        (Some(value.to_string()), None)
+    }
+}
+
+fn write_callback_response(mut stream: TcpStream, ok: bool, message: &str) {
+    let title = if ok {
+        "OpenAI login complete"
+    } else {
+        "OpenAI login failed"
+    };
+    let body = format!(
+        "<!doctype html><meta charset=\"utf-8\"><title>{}</title><body style=\"font-family: system-ui; margin: 3rem\"><h1>{}</h1><p>{}</p></body>",
+        title, title, message
+    );
+    let status = if ok { "200 OK" } else { "400 Bad Request" };
+    let response = format!(
+        "HTTP/1.1 {status}\r\ncontent-type: text/html; charset=utf-8\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{}",
+        body.len(),
+        body
+    );
+    let _ = stream.write_all(response.as_bytes());
+}
+
+fn wait_for_browser_callback(state: String) -> Result<String> {
+    let listener = TcpListener::bind("127.0.0.1:1455")
+        .context("binding OAuth callback server on 127.0.0.1:1455")?;
+    let (mut stream, _) = listener.accept().context("waiting for OAuth callback")?;
+    let mut buf = [0u8; 8192];
+    let n = stream.read(&mut buf).unwrap_or(0);
+    let request = String::from_utf8_lossy(&buf[..n]);
+    let first = request.lines().next().unwrap_or_default();
+    let path = first.split_whitespace().nth(1).unwrap_or_default();
+    if !path.starts_with("/auth/callback") {
+        write_callback_response(stream, false, "Callback route not found.");
+        return Err(anyhow!("unexpected OAuth callback path"));
+    }
+    let got_state = query_param(path, "state");
+    if got_state.as_deref() != Some(state.as_str()) {
+        write_callback_response(stream, false, "State mismatch.");
+        return Err(anyhow!("OAuth state mismatch"));
+    }
+    let code = query_param(path, "code").ok_or_else(|| anyhow!("OAuth callback missing code"))?;
+    write_callback_response(
+        stream,
+        true,
+        "OpenAI authentication completed. You can close this window.",
+    );
+    Ok(code)
+}
+
+fn open_browser(url: &str) -> Result<()> {
+    #[cfg(target_os = "macos")]
+    let mut cmd = std::process::Command::new("open");
+    #[cfg(target_os = "linux")]
+    let mut cmd = std::process::Command::new("xdg-open");
+    #[cfg(target_os = "windows")]
+    let mut cmd = {
+        let mut c = std::process::Command::new("cmd");
+        c.args(["/C", "start", ""]);
+        c
+    };
+    cmd.arg(url);
+    cmd.spawn().context("opening browser")?;
+    Ok(())
+}
+
+#[derive(Debug, Deserialize)]
+struct TokenResponse {
+    access_token: String,
+    refresh_token: String,
+    expires_in: u64,
+}
+
+async fn read_token_response(resp: reqwest::Response, operation: &str) -> Result<OAuthCredential> {
+    if !resp.status().is_success() {
+        let status = resp.status();
+        let body = resp.text().await.unwrap_or_default();
+        return Err(anyhow!(
+            "OpenAI Codex token {operation} failed ({status}): {}",
+            body.trim()
+        ));
+    }
+    let token: TokenResponse = resp.json().await?;
+    let account_id = account_id_from_access_token(&token.access_token);
+    Ok(OAuthCredential {
+        credential_type: "oauth".into(),
+        access: token.access_token,
+        refresh: token.refresh_token,
+        expires: now_secs() + token.expires_in,
+        account_id,
+    })
+}
+
+async fn exchange_authorization_code(
+    client: &reqwest::Client,
+    code: &str,
+    verifier: &str,
+    redirect_uri: &str,
+) -> Result<OAuthCredential> {
+    let body = form_urlencoded(&[
+        ("grant_type", "authorization_code"),
+        ("client_id", CLIENT_ID),
+        ("code", code),
+        ("code_verifier", verifier),
+        ("redirect_uri", redirect_uri),
+    ]);
+    let resp = client
+        .post(TOKEN_URL)
+        .header("Content-Type", "application/x-www-form-urlencoded")
+        .body(body)
+        .send()
+        .await?;
+    read_token_response(resp, "exchange").await
+}
+
+pub async fn refresh_oauth(client: &reqwest::Client, refresh: &str) -> Result<OAuthCredential> {
+    let body = form_urlencoded(&[
+        ("grant_type", "refresh_token"),
+        ("refresh_token", refresh),
+        ("client_id", CLIENT_ID),
+    ]);
+    let resp = client
+        .post(TOKEN_URL)
+        .header("Content-Type", "application/x-www-form-urlencoded")
+        .body(body)
+        .send()
+        .await?;
+    read_token_response(resp, "refresh").await
+}
+
+fn save_oauth(credential: OAuthCredential) -> Result<PathBuf> {
+    let mut store = AuthStore::load();
+    store.set_oauth(PROVIDER, credential);
+    store.save()?;
+    auth_file_path().context("no auth file path")
+}
+
+pub async fn login_browser(client: &reqwest::Client) -> Result<OAuthCredential> {
+    let (verifier, challenge) = pkce_pair();
+    let state = random_hex(16);
+    let url = authorization_url(&state, &challenge);
+    println!("  Open this URL to sign in with ChatGPT/Codex:\n\n  {url}\n");
+    if let Err(e) = open_browser(&url) {
+        println!("  Browser did not open automatically: {e}");
+    }
+    println!("  Waiting for callback on {REDIRECT_URI} ...");
+    let state_for_thread = state.clone();
+    let callback = tokio::task::spawn_blocking(move || wait_for_browser_callback(state_for_thread))
+        .await
+        .context("joining OAuth callback task")?;
+    let code = match callback {
+        Ok(code) => code,
+        Err(e) => {
+            println!("  Callback failed: {e}");
+            let input = plain_read_line(
+                "  Paste the authorization code or full redirect URL (blank to cancel): ".into(),
+            )
+            .await?;
+            let (code, got_state) = parse_authorization_input(&input);
+            if let Some(got_state) = got_state {
+                if got_state != state {
+                    return Err(anyhow!("OAuth state mismatch"));
+                }
+            }
+            code.ok_or_else(|| anyhow!("missing authorization code"))?
+        }
+    };
+    exchange_authorization_code(client, &code, &verifier, REDIRECT_URI).await
+}
+
+#[derive(Debug, Deserialize)]
+struct DeviceStartResponse {
+    device_auth_id: String,
+    user_code: String,
+    interval: Value,
+}
+
+#[derive(Debug, Deserialize)]
+struct DeviceTokenResponse {
+    authorization_code: String,
+    code_verifier: String,
+}
+
+pub async fn login_device_code(client: &reqwest::Client) -> Result<OAuthCredential> {
+    let resp = client
+        .post(DEVICE_USER_CODE_URL)
+        .json(&serde_json::json!({ "client_id": CLIENT_ID }))
+        .send()
+        .await?;
+    if !resp.status().is_success() {
+        let status = resp.status();
+        let body = resp.text().await.unwrap_or_default();
+        return Err(anyhow!(
+            "OpenAI Codex device-code request failed ({status}): {}",
+            body.trim()
+        ));
+    }
+    let device: DeviceStartResponse = resp.json().await?;
+    let interval = device
+        .interval
+        .as_u64()
+        .or_else(|| device.interval.as_str().and_then(|s| s.parse().ok()))
+        .unwrap_or(5)
+        .max(1);
+    println!("  Open: {DEVICE_VERIFICATION_URI}");
+    println!("  Code: {}", device.user_code);
+    println!("  Waiting for approval ...");
+
+    let deadline = now_secs() + 15 * 60;
+    loop {
+        if now_secs() > deadline {
+            return Err(anyhow!("device-code login timed out"));
+        }
+        tokio::time::sleep(Duration::from_secs(interval)).await;
+        let resp = client
+            .post(DEVICE_TOKEN_URL)
+            .json(&serde_json::json!({
+                "device_auth_id": device.device_auth_id,
+                "user_code": device.user_code,
+            }))
+            .send()
+            .await?;
+        if resp.status().is_success() {
+            let complete: DeviceTokenResponse = resp.json().await?;
+            return exchange_authorization_code(
+                client,
+                &complete.authorization_code,
+                &complete.code_verifier,
+                DEVICE_REDIRECT_URI,
+            )
+            .await;
+        }
+        let status = resp.status();
+        let body = resp.text().await.unwrap_or_default();
+        let pending = status.as_u16() == 403
+            || status.as_u16() == 404
+            || body.contains("deviceauth_authorization_pending")
+            || body.contains("authorization_pending");
+        if pending {
+            continue;
+        }
+        if body.contains("slow_down") {
+            tokio::time::sleep(Duration::from_secs(interval)).await;
+            continue;
+        }
+        return Err(anyhow!(
+            "OpenAI Codex device-code polling failed ({status}): {}",
+            body.trim()
+        ));
+    }
+}
+
+pub async fn login_and_save_browser(client: &reqwest::Client) -> Result<PathBuf> {
+    let credential = login_browser(client).await?;
+    save_oauth(credential)
+}
+
+pub async fn login_and_save_device_code(client: &reqwest::Client) -> Result<PathBuf> {
+    let credential = login_device_code(client).await?;
+    save_oauth(credential)
+}
+
+pub async fn access_token(client: &reqwest::Client) -> Result<(String, String)> {
+    let store = AuthStore::load();
+    let credential = store
+        .get_oauth(PROVIDER)
+        .cloned()
+        .ok_or_else(|| anyhow!("not logged in for openai-codex; run `/login openai-codex`"))?;
+    let credential = if credential.expires <= now_secs() + 60 {
+        let refreshed = refresh_oauth(client, &credential.refresh).await?;
+        let mut store = AuthStore::load();
+        store.set_oauth(PROVIDER, refreshed.clone());
+        store.save()?;
+        refreshed
+    } else {
+        credential
+    };
+    let account_id = credential
+        .account_id
+        .clone()
+        .or_else(|| account_id_from_access_token(&credential.access))
+        .ok_or_else(|| anyhow!("failed to extract ChatGPT account ID from Codex access token"))?;
+    Ok((credential.access, account_id))
+}
+
+pub fn account_id_from_access_token(token: &str) -> Option<String> {
+    let payload = token.split('.').nth(1)?;
+    let decoded = URL_SAFE_NO_PAD.decode(payload).ok()?;
+    let json: Value = serde_json::from_slice(&decoded).ok()?;
+    json.get(JWT_CLAIM_PATH)?
+        .get("chatgpt_account_id")?
+        .as_str()
+        .filter(|s| !s.is_empty())
+        .map(ToString::to_string)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn authorization_url_has_codex_oauth_params() {
+        let url = authorization_url("state", "challenge");
+        assert!(url.starts_with("https://auth.openai.com"));
+        assert!(url.contains("client_id=app_EMoamEEZ73f0CkXaXp7hrann"));
+        assert!(url.contains("code_challenge_method=S256"));
+        assert!(url.contains("codex_cli_simplified_flow=true"));
+    }
+
+    #[test]
+    fn parses_redirect_url_input() {
+        let (code, state) = parse_authorization_input(
+            "http://localhost:1455/auth/callback?code=abc%20123&state=st",
+        );
+        assert_eq!(code.as_deref(), Some("abc 123"));
+        assert_eq!(state.as_deref(), Some("st"));
+    }
+}

--- a/src/codex_responses.rs
+++ b/src/codex_responses.rs
@@ -1,0 +1,567 @@
+use anyhow::{anyhow, Result};
+use futures_util::StreamExt;
+use serde_json::{json, Value};
+use std::collections::BTreeMap;
+
+use crate::backends::BackendDescriptor;
+use crate::cancel::CancellationToken;
+use crate::codex_oauth;
+use crate::openai::{
+    ChatMessage, ChatRequest, StreamChoice, StreamChunk, StreamDelta, ToolCallDelta,
+    ToolFunctionDelta, Usage, UserContent, UserContentPart,
+};
+
+fn resolve_codex_url(base_url: &str) -> String {
+    let normalized = base_url.trim_end_matches('/');
+    if normalized.ends_with("/codex/responses") {
+        normalized.to_string()
+    } else if normalized.ends_with("/codex") {
+        format!("{normalized}/responses")
+    } else {
+        format!("{normalized}/codex/responses")
+    }
+}
+
+fn user_content_parts(content: &UserContent) -> Vec<Value> {
+    match content {
+        UserContent::Text(text) => vec![json!({ "type": "input_text", "text": text })],
+        UserContent::Parts(parts) => parts
+            .iter()
+            .map(|part| match part {
+                UserContentPart::Text { text } => json!({ "type": "input_text", "text": text }),
+                UserContentPart::ImageUrl { image_url } => {
+                    json!({ "type": "input_image", "image_url": image_url.url })
+                }
+            })
+            .collect(),
+    }
+}
+
+fn build_request_body(req: &ChatRequest<'_>) -> Value {
+    let model = canonical_codex_model(req.model).unwrap_or(req.model);
+    let mut instructions = Vec::new();
+    let mut input = Vec::new();
+
+    for message in req.messages {
+        match message {
+            ChatMessage::System { content } => instructions.push(content.clone()),
+            ChatMessage::User { content } => input.push(json!({
+                "role": "user",
+                "content": user_content_parts(content),
+            })),
+            ChatMessage::Assistant {
+                content,
+                tool_calls,
+            } => {
+                if let Some(text) = content.as_ref().filter(|s| !s.is_empty()) {
+                    input.push(json!({
+                        "role": "assistant",
+                        "content": [{ "type": "output_text", "text": text }],
+                    }));
+                }
+                for call in tool_calls {
+                    input.push(json!({
+                        "type": "function_call",
+                        "call_id": call.id,
+                        "name": call.function.name,
+                        "arguments": call.function.arguments,
+                    }));
+                }
+            }
+            ChatMessage::Tool {
+                tool_call_id,
+                content,
+            } => input.push(json!({
+                "type": "function_call_output",
+                "call_id": tool_call_id,
+                "output": content,
+            })),
+        }
+    }
+
+    let mut body = json!({
+        "model": model,
+        "store": false,
+        "stream": true,
+        "instructions": if instructions.is_empty() { "You are a helpful assistant.".to_string() } else { instructions.join("\n\n") },
+        "input": input,
+        "text": { "verbosity": "low" },
+        "include": ["reasoning.encrypted_content"],
+        "tool_choice": "auto",
+        "parallel_tool_calls": true,
+    });
+
+    // Pi's ChatGPT/Codex OAuth provider does not send `max_output_tokens` to
+    // `chatgpt.com/backend-api/codex/responses`; the backend rejects it with
+    // `Unsupported parameter: max_output_tokens`. Keep Small Harness' normal
+    // Chat Completions cap out of this adapter.
+    if let Some(tools) = req.tools {
+        body["tools"] = Value::Array(
+            tools
+                .iter()
+                .map(|tool| {
+                    json!({
+                        "type": "function",
+                        "name": tool.function.name,
+                        "description": tool.function.description,
+                        "parameters": tool.function.parameters,
+                    })
+                })
+                .collect(),
+        );
+    }
+    body
+}
+
+#[derive(Debug, Default)]
+struct RawSseParser {
+    buf: Vec<u8>,
+    data: String,
+}
+
+impl RawSseParser {
+    fn feed(&mut self, bytes: &[u8]) -> Result<Vec<Value>> {
+        self.buf.extend_from_slice(bytes);
+        let mut out = Vec::new();
+        while let Some(pos) = self.buf.iter().position(|&b| b == b'\n') {
+            let line: Vec<u8> = self.buf.drain(..=pos).collect();
+            let line = std::str::from_utf8(&line)?.trim_end_matches(['\r', '\n']);
+            if line.is_empty() {
+                if !self.data.is_empty() {
+                    if self.data.trim() != "[DONE]" {
+                        out.push(serde_json::from_str(&self.data)?);
+                    }
+                    self.data.clear();
+                }
+            } else if let Some(rest) = line.strip_prefix("data:") {
+                let rest = rest.strip_prefix(' ').unwrap_or(rest);
+                if !self.data.is_empty() {
+                    self.data.push('\n');
+                }
+                self.data.push_str(rest);
+            }
+        }
+        Ok(out)
+    }
+
+    fn finalize(&mut self) -> Result<Vec<Value>> {
+        let mut out = Vec::new();
+        if !self.data.is_empty() && self.data.trim() != "[DONE]" {
+            out.push(serde_json::from_str(&self.data)?);
+        }
+        self.data.clear();
+        Ok(out)
+    }
+}
+
+#[derive(Debug, Default, Clone)]
+struct CallState {
+    index: usize,
+    id: String,
+    name: String,
+    arguments: String,
+}
+
+fn one_content_chunk(delta: String) -> StreamChunk {
+    StreamChunk {
+        choices: vec![StreamChoice {
+            delta: StreamDelta {
+                content: Some(delta),
+                reasoning: None,
+                tool_calls: None,
+            },
+        }],
+        usage: None,
+    }
+}
+
+fn one_reasoning_chunk(delta: String) -> StreamChunk {
+    StreamChunk {
+        choices: vec![StreamChoice {
+            delta: StreamDelta {
+                content: None,
+                reasoning: Some(delta),
+                tool_calls: None,
+            },
+        }],
+        usage: None,
+    }
+}
+
+fn one_tool_chunk(
+    index: usize,
+    id: Option<String>,
+    name: Option<String>,
+    args: Option<String>,
+) -> StreamChunk {
+    StreamChunk {
+        choices: vec![StreamChoice {
+            delta: StreamDelta {
+                content: None,
+                reasoning: None,
+                tool_calls: Some(vec![ToolCallDelta {
+                    index: Some(index),
+                    id,
+                    function: Some(ToolFunctionDelta {
+                        name,
+                        arguments: args,
+                    }),
+                }]),
+            },
+        }],
+        usage: None,
+    }
+}
+
+fn usage_chunk(input: u32, output: u32) -> StreamChunk {
+    StreamChunk {
+        choices: Vec::new(),
+        usage: Some(Usage {
+            prompt_tokens: input,
+            completion_tokens: output,
+        }),
+    }
+}
+
+fn val_str<'a>(v: &'a Value, keys: &[&str]) -> Option<&'a str> {
+    keys.iter().find_map(|k| v.get(*k)?.as_str())
+}
+
+fn val_usize(v: &Value, keys: &[&str]) -> Option<usize> {
+    keys.iter()
+        .find_map(|k| v.get(*k)?.as_u64().map(|n| n as usize))
+}
+
+fn handle_event<F>(
+    event: Value,
+    calls: &mut BTreeMap<String, CallState>,
+    next_index: &mut usize,
+    mut on_chunk: F,
+) -> Result<bool>
+where
+    F: FnMut(StreamChunk),
+{
+    let kind = event
+        .get("type")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    match kind {
+        "response.output_text.delta" => {
+            if let Some(delta) = event.get("delta").and_then(Value::as_str) {
+                if !delta.is_empty() {
+                    on_chunk(one_content_chunk(delta.to_string()));
+                }
+            }
+        }
+        "response.reasoning_summary_text.delta" | "response.reasoning_text.delta" => {
+            if let Some(delta) = event.get("delta").and_then(Value::as_str) {
+                if !delta.is_empty() {
+                    on_chunk(one_reasoning_chunk(delta.to_string()));
+                }
+            }
+        }
+        "response.output_item.added" => {
+            let item = event.get("item").unwrap_or(&Value::Null);
+            if item.get("type").and_then(Value::as_str) == Some("function_call") {
+                let item_id = val_str(item, &["id", "item_id"])
+                    .or_else(|| val_str(&event, &["item_id", "id"]))
+                    .unwrap_or("")
+                    .to_string();
+                let call_id = val_str(item, &["call_id"])
+                    .unwrap_or(item_id.as_str())
+                    .to_string();
+                let name = val_str(item, &["name"]).unwrap_or("").to_string();
+                let index = val_usize(&event, &["output_index", "index"]).unwrap_or_else(|| {
+                    let i = *next_index;
+                    *next_index += 1;
+                    i
+                });
+                calls.insert(
+                    item_id.clone(),
+                    CallState {
+                        index,
+                        id: call_id.clone(),
+                        name: name.clone(),
+                        arguments: String::new(),
+                    },
+                );
+                on_chunk(one_tool_chunk(index, Some(call_id), Some(name), None));
+            }
+        }
+        "response.function_call_arguments.delta" => {
+            let item_id = val_str(&event, &["item_id", "id"])
+                .map(ToString::to_string)
+                .unwrap_or_else(|| calls.keys().last().cloned().unwrap_or_default());
+            let delta = event
+                .get("delta")
+                .and_then(Value::as_str)
+                .unwrap_or_default()
+                .to_string();
+            if !delta.is_empty() {
+                let entry = calls.entry(item_id).or_insert_with(|| {
+                    let i = *next_index;
+                    *next_index += 1;
+                    CallState {
+                        index: i,
+                        id: String::new(),
+                        name: String::new(),
+                        arguments: String::new(),
+                    }
+                });
+                entry.arguments.push_str(&delta);
+                on_chunk(one_tool_chunk(entry.index, None, None, Some(delta)));
+            }
+        }
+        "response.output_item.done" => {
+            let item = event.get("item").unwrap_or(&Value::Null);
+            if item.get("type").and_then(Value::as_str) == Some("function_call") {
+                let item_id = val_str(item, &["id", "item_id"])
+                    .or_else(|| val_str(&event, &["item_id", "id"]))
+                    .unwrap_or("")
+                    .to_string();
+                let call_id = val_str(item, &["call_id"]).unwrap_or("").to_string();
+                let name = val_str(item, &["name"]).unwrap_or("").to_string();
+                let args = val_str(item, &["arguments"]).unwrap_or("").to_string();
+                let entry = calls.entry(item_id).or_insert_with(|| {
+                    let i = *next_index;
+                    *next_index += 1;
+                    CallState {
+                        index: i,
+                        id: call_id.clone(),
+                        name: name.clone(),
+                        arguments: String::new(),
+                    }
+                });
+                if entry.id.is_empty() && !call_id.is_empty()
+                    || entry.name.is_empty() && !name.is_empty()
+                {
+                    if !call_id.is_empty() {
+                        entry.id = call_id.clone();
+                    }
+                    if !name.is_empty() {
+                        entry.name = name.clone();
+                    }
+                    on_chunk(one_tool_chunk(
+                        entry.index,
+                        (!call_id.is_empty()).then_some(call_id),
+                        (!name.is_empty()).then_some(name),
+                        None,
+                    ));
+                }
+                if !args.is_empty() && args != entry.arguments {
+                    let delta = if args.starts_with(&entry.arguments) {
+                        args[entry.arguments.len()..].to_string()
+                    } else {
+                        args.clone()
+                    };
+                    if !delta.is_empty() {
+                        entry.arguments = args;
+                        on_chunk(one_tool_chunk(entry.index, None, None, Some(delta)));
+                    }
+                }
+            }
+        }
+        "response.completed" => {
+            if let Some(usage) = event.get("response").and_then(|r| r.get("usage")) {
+                let input = usage
+                    .get("input_tokens")
+                    .and_then(Value::as_u64)
+                    .unwrap_or(0) as u32;
+                let output = usage
+                    .get("output_tokens")
+                    .and_then(Value::as_u64)
+                    .unwrap_or(0) as u32;
+                if input > 0 || output > 0 {
+                    on_chunk(usage_chunk(input, output));
+                }
+            }
+            return Ok(true);
+        }
+        "response.failed" => {
+            let error = event
+                .get("response")
+                .and_then(|r| r.get("error"))
+                .and_then(|e| e.get("message"))
+                .and_then(Value::as_str)
+                .unwrap_or("Codex response failed");
+            return Err(anyhow!(error.to_string()));
+        }
+        "error" => {
+            let msg = event
+                .get("message")
+                .and_then(Value::as_str)
+                .unwrap_or("Codex stream error");
+            return Err(anyhow!(msg.to_string()));
+        }
+        _ => {}
+    }
+    Ok(false)
+}
+
+pub async fn stream_codex_responses<F>(
+    client: &reqwest::Client,
+    backend: &BackendDescriptor,
+    req: &ChatRequest<'_>,
+    cancel: Option<CancellationToken>,
+    mut on_chunk: F,
+) -> Result<()>
+where
+    F: FnMut(StreamChunk),
+{
+    let Some(_model) = canonical_codex_model(req.model) else {
+        return Err(anyhow!(
+            "{} is not supported with ChatGPT/Codex login. Try one of: {}",
+            req.model,
+            codex_model_list().join(", ")
+        ));
+    };
+    let (access_token, account_id) = codex_oauth::access_token(client).await?;
+    let url = resolve_codex_url(&backend.base_url);
+    let body = build_request_body(req);
+    let resp = client
+        .post(url)
+        .bearer_auth(&access_token)
+        .header("chatgpt-account-id", account_id)
+        .header("originator", "small-harness")
+        .header("OpenAI-Beta", "responses=experimental")
+        .header("accept", "text/event-stream")
+        .header("content-type", "application/json")
+        .json(&body)
+        .send()
+        .await?;
+    if !resp.status().is_success() {
+        let status = resp.status();
+        let body = resp.text().await.unwrap_or_default();
+        return Err(anyhow!("Codex HTTP {}: {}", status, body.trim()));
+    }
+
+    let mut stream = resp.bytes_stream();
+    let mut parser = RawSseParser::default();
+    let mut calls = BTreeMap::new();
+    let mut next_index = 0usize;
+    loop {
+        let next = if let Some(cancel) = cancel.clone() {
+            tokio::select! {
+                _ = cancel.cancelled() => return Err(anyhow!("cancelled")),
+                chunk = stream.next() => chunk,
+            }
+        } else {
+            stream.next().await
+        };
+        let Some(chunk) = next else {
+            break;
+        };
+        let chunk = chunk?;
+        for event in parser.feed(&chunk)? {
+            if handle_event(event, &mut calls, &mut next_index, &mut on_chunk)? {
+                return Ok(());
+            }
+        }
+    }
+    for event in parser.finalize()? {
+        if handle_event(event, &mut calls, &mut next_index, &mut on_chunk)? {
+            return Ok(());
+        }
+    }
+    Ok(())
+}
+
+pub fn codex_model_list() -> Vec<String> {
+    vec![
+        "gpt-5.5".into(),
+        "gpt-5.4".into(),
+        "gpt-5.4-mini".into(),
+        "gpt-5.3-codex-spark".into(),
+    ]
+}
+
+/// Canonical ChatGPT/Codex OAuth model ids from Pi's current openai-codex
+/// catalog.  Accept a few shorthand aliases because users often type `5.5`,
+/// but never send those aliases over the wire.
+pub fn canonical_codex_model(model: &str) -> Option<&'static str> {
+    match model.trim() {
+        "gpt-5.5" | "5.5" => Some("gpt-5.5"),
+        "gpt-5.4" | "5.4" => Some("gpt-5.4"),
+        "gpt-5.4-mini" | "5.4-mini" => Some("gpt-5.4-mini"),
+        "gpt-5.3-codex-spark" | "5.3-codex-spark" | "spark" => Some("gpt-5.3-codex-spark"),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::openai::{ToolDef, ToolDefFunction};
+
+    #[test]
+    fn resolves_codex_url_variants() {
+        assert_eq!(
+            resolve_codex_url("https://chatgpt.com/backend-api"),
+            "https://chatgpt.com/backend-api/codex/responses"
+        );
+        assert_eq!(
+            resolve_codex_url("https://chatgpt.com/backend-api/codex"),
+            "https://chatgpt.com/backend-api/codex/responses"
+        );
+    }
+
+    #[test]
+    fn request_body_uses_responses_tools_shape() {
+        let messages = [
+            ChatMessage::System {
+                content: "sys".into(),
+            },
+            ChatMessage::User {
+                content: "hi".into(),
+            },
+        ];
+        let tools = [ToolDef {
+            kind: "function",
+            function: ToolDefFunction {
+                name: "grep".into(),
+                description: "search".into(),
+                parameters: json!({ "type": "object" }),
+            },
+        }];
+        let req = ChatRequest {
+            model: "5.5",
+            messages: &messages,
+            tools: Some(&tools),
+            stream: true,
+            stream_options: None,
+            max_tokens: None,
+        };
+        let body = build_request_body(&req);
+        assert_eq!(body["instructions"], "sys");
+        assert_eq!(body["model"], "gpt-5.5");
+        assert_eq!(body["tools"][0]["type"], "function");
+        assert_eq!(body["tools"][0]["name"], "grep");
+    }
+
+    #[test]
+    fn canonicalizes_pi_codex_oauth_models_and_aliases() {
+        assert_eq!(canonical_codex_model("gpt-5.5"), Some("gpt-5.5"));
+        assert_eq!(canonical_codex_model("5.5"), Some("gpt-5.5"));
+        assert_eq!(canonical_codex_model("gpt-5-codex"), None);
+    }
+
+    #[test]
+    fn maps_text_and_tool_events_to_chat_chunks() {
+        let mut chunks = Vec::new();
+        let mut calls = BTreeMap::new();
+        let mut next_index = 0;
+        handle_event(
+            json!({"type":"response.output_text.delta","delta":"hi"}),
+            &mut calls,
+            &mut next_index,
+            |c| chunks.push(c),
+        )
+        .unwrap();
+        handle_event(json!({"type":"response.output_item.added","output_index":0,"item":{"type":"function_call","id":"fc_1","call_id":"call_1","name":"grep"}}), &mut calls, &mut next_index, |c| chunks.push(c)).unwrap();
+        handle_event(json!({"type":"response.function_call_arguments.delta","item_id":"fc_1","delta":"{\"pattern\":"}), &mut calls, &mut next_index, |c| chunks.push(c)).unwrap();
+        assert_eq!(chunks[0].choices[0].delta.content.as_deref(), Some("hi"));
+        let call = chunks[1].choices[0].delta.tool_calls.as_ref().unwrap()[0].clone();
+        assert_eq!(call.id.as_deref(), Some("call_1"));
+        assert_eq!(call.function.unwrap().name.as_deref(), Some("grep"));
+    }
+}

--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -60,10 +60,20 @@ async fn cmd_doctor_probe(args: &str, state: &AppState) -> Result<()> {
         Ok(_) => println!("  {GREEN}✓{RESET} {DIM}session dir writable{RESET}"),
         Err(e) => println!("  {RED}✗{RESET} {DIM}session dir not writable: {e}{RESET}"),
     }
-    if !state.config.backend.is_local() && state.backend.api_key.is_empty() {
+    if matches!(state.config.backend, BackendName::OpenAiCodex) {
+        if crate::auth::AuthStore::load()
+            .get_oauth("openai-codex")
+            .is_none()
+        {
+            println!(
+                "  {RED}✗{RESET} {DIM}openai-codex login missing; run /login openai-codex{RESET}"
+            );
+        }
+    } else if !state.config.backend.is_local() && state.backend.api_key.is_empty() {
         let env_name = match state.config.backend {
             BackendName::Openrouter => "OPENROUTER_API_KEY",
             BackendName::OpenAi => "OPENAI_API_KEY",
+            BackendName::OpenAiCodex => "ChatGPT login",
             _ => "API key",
         };
         println!("  {RED}✗{RESET} {DIM}{env_name} missing{RESET}");
@@ -939,6 +949,7 @@ fn backend_model_hint(backend_name: BackendName, model: &str) -> String {
         }
         BackendName::Openrouter => "set OPENROUTER_API_KEY before using OpenRouter".into(),
         BackendName::OpenAi => "set OPENAI_API_KEY before using OpenAI".into(),
+        BackendName::OpenAiCodex => "run /login openai-codex before using ChatGPT/Codex".into(),
     }
 }
 

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -130,8 +130,13 @@ pub const COMMANDS: &[(&str, &str)] = &[
     ("/export", "Export a session to markdown or json"),
     (
         "/auth",
-        "Manage API keys for cloud providers (list, set <provider>, clear <provider>)",
+        "Manage API keys and OAuth credentials (list, set, clear, login)",
     ),
+    (
+        "/login",
+        "Browser/device-code login for subscription providers (openai-codex)",
+    ),
+    ("/logout", "Clear an OAuth login (openai-codex)"),
     (
         "/image",
         "Attach an image to the next user prompt (vision-capable models only)",
@@ -146,7 +151,7 @@ pub const COMMANDS: &[(&str, &str)] = &[
     ),
     (
         "/backend",
-        "Switch backend (ollama, lm-studio, mlx, llamacpp, openrouter)",
+        "Switch backend (ollama, lm-studio, mlx, llamacpp, openrouter, openai, openai-codex)",
     ),
     (
         "/model",
@@ -235,6 +240,8 @@ pub async fn dispatch(input: &str, state: &mut AppState) -> Result<()> {
         "/resume" => cmd_resume(&args, state)?,
         "/export" => cmd_export(&args, state)?,
         "/auth" => cmd_auth(&args).await?,
+        "/login" => cmd_login(&args, state).await?,
+        "/logout" => cmd_logout(&args)?,
         "/image" => cmd_image(&args, state),
         "/reasoning" => cmd_reasoning(&args, state),
         "/verbose" => cmd_verbose(&args, state),
@@ -1574,6 +1581,10 @@ async fn cmd_auth(args: &str) -> Result<()> {
             }
             Ok(())
         }
+        "login" => {
+            let mut login_state = AppStateLoginOnly;
+            cmd_login(rest, &mut login_state).await
+        }
         "clear" => {
             if rest.is_empty() {
                 println!("  {DIM}usage: /auth clear <provider>{RESET}");
@@ -1596,11 +1607,101 @@ async fn cmd_auth(args: &str) -> Result<()> {
         }
         other => {
             println!(
-                "  {RED}✗{RESET} {DIM}unknown subcommand: {other} (try: list, set, clear){RESET}"
+                "  {RED}✗{RESET} {DIM}unknown subcommand: {other} (try: list, set, login, clear){RESET}"
             );
             Ok(())
         }
     }
+}
+
+struct AppStateLoginOnly;
+
+async fn cmd_login(args: &str, state: &mut impl LoginState) -> Result<()> {
+    let provider = if args.trim().is_empty() {
+        "openai-codex"
+    } else {
+        args.trim()
+    };
+    if !matches!(provider, "openai-codex" | "codex" | "chatgpt") {
+        println!(
+            "  {RED}✗{RESET} {DIM}unknown login provider: {provider} (try: openai-codex){RESET}"
+        );
+        return Ok(());
+    }
+
+    println!("  {BOLD}ChatGPT / Codex login{RESET}");
+    println!(
+        "  {DIM}This uses your ChatGPT/Codex subscription OAuth token, not OPENAI_API_KEY.{RESET}"
+    );
+    println!("  {DIM}1) Browser login (default){RESET}");
+    println!("  {DIM}2) Device-code login (headless/SSH){RESET}");
+    let pick = plain_read_line(format!("  {DIM}Select [1]: {RESET}")).await?;
+    let result = if pick.trim() == "2" || pick.trim().eq_ignore_ascii_case("device") {
+        crate::codex_oauth::login_and_save_device_code(state.http()).await
+    } else {
+        crate::codex_oauth::login_and_save_browser(state.http()).await
+    };
+    match result {
+        Ok(path) => {
+            println!(
+                "  {GREEN}✓{RESET} {DIM}logged in to openai-codex; saved to {}{RESET}",
+                path.display()
+            );
+            state.after_login()?;
+        }
+        Err(e) => println!("  {RED}✗{RESET} {DIM}login failed: {e}{RESET}"),
+    }
+    Ok(())
+}
+
+trait LoginState {
+    fn http(&self) -> &reqwest::Client;
+    fn after_login(&mut self) -> Result<()>;
+}
+
+impl LoginState for AppState {
+    fn http(&self) -> &reqwest::Client {
+        &self.http
+    }
+    fn after_login(&mut self) -> Result<()> {
+        if matches!(self.config.backend, BackendName::OpenAiCodex) {
+            self.rebuild_client()?;
+            self.resolve_model();
+        }
+        Ok(())
+    }
+}
+
+impl LoginState for AppStateLoginOnly {
+    fn http(&self) -> &reqwest::Client {
+        static CLIENT: std::sync::OnceLock<reqwest::Client> = std::sync::OnceLock::new();
+        CLIENT.get_or_init(crate::openai::build_http_client)
+    }
+    fn after_login(&mut self) -> Result<()> {
+        Ok(())
+    }
+}
+
+fn cmd_logout(args: &str) -> Result<()> {
+    let provider = if args.trim().is_empty() {
+        "openai-codex"
+    } else {
+        args.trim()
+    };
+    if !matches!(provider, "openai-codex" | "codex" | "chatgpt") {
+        println!(
+            "  {RED}✗{RESET} {DIM}unknown logout provider: {provider} (try: openai-codex){RESET}"
+        );
+        return Ok(());
+    }
+    let mut store = crate::auth::AuthStore::load();
+    if store.clear("openai-codex") {
+        store.save()?;
+        println!("  {GREEN}✓{RESET} {DIM}cleared openai-codex login{RESET}");
+    } else {
+        println!("  {DIM}no stored openai-codex login{RESET}");
+    }
+    Ok(())
 }
 
 fn print_auth_status() {
@@ -1617,6 +1718,31 @@ fn print_auth_status() {
             ("(not set)".into(), "—".into())
         };
         println!("  {:<12} {:<22}  {DIM}{}{RESET}", provider, display, source);
+    }
+    if let Some(oauth) = store.get_oauth("openai-codex") {
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0);
+        let status = if oauth.expires > now + 60 {
+            "oauth logged in"
+        } else {
+            "oauth refresh needed"
+        };
+        let source = oauth
+            .account_id
+            .as_ref()
+            .map(|id| format!("auth file · account {id}"))
+            .unwrap_or_else(|| "auth file".into());
+        println!(
+            "  {:<12} {:<22}  {DIM}{}{RESET}",
+            "openai-codex", status, source
+        );
+    } else {
+        println!(
+            "  {:<12} {:<22}  {DIM}{}{RESET}",
+            "openai-codex", "(not logged in)", "/login openai-codex"
+        );
     }
     if let Some(path) = auth_file_path() {
         println!("  {DIM}file{RESET}     {}", path.display());
@@ -1770,10 +1896,24 @@ async fn cmd_backend(args: &str, state: &mut AppState) -> Result<()> {
         println!("  {DIM}Cancelled.{RESET}");
         return Ok(());
     };
-    if !chosen.is_local() && backend(chosen).api_key.is_empty() {
+    if matches!(chosen, BackendName::OpenAiCodex)
+        && crate::auth::AuthStore::load()
+            .get_oauth("openai-codex")
+            .is_none()
+    {
+        println!(
+            "  {RED}✗{RESET} {DIM}not logged in for openai-codex. Run /login openai-codex to sign in with ChatGPT.{RESET}"
+        );
+        return Ok(());
+    }
+    if !chosen.is_local()
+        && !matches!(chosen, BackendName::OpenAiCodex)
+        && backend(chosen).api_key.is_empty()
+    {
         let env_name = match chosen {
             BackendName::Openrouter => "OPENROUTER_API_KEY",
             BackendName::OpenAi => "OPENAI_API_KEY",
+            BackendName::OpenAiCodex => "ChatGPT login",
             _ => "API key",
         };
         println!("  {RED}✗{RESET} {DIM}{env_name} not set in environment.{RESET}");
@@ -1794,7 +1934,19 @@ async fn cmd_backend(args: &str, state: &mut AppState) -> Result<()> {
 async fn cmd_model(args: &str, state: &mut AppState) -> Result<()> {
     use std::io::Write;
     if !args.is_empty() {
-        state.config.model_override = Some(args.to_string());
+        let model_override = if matches!(state.config.backend, BackendName::OpenAiCodex) {
+            let Some(canonical) = crate::codex_responses::canonical_codex_model(args) else {
+                println!(
+                    "  {RED}✗{RESET} {DIM}{args} is not supported with ChatGPT/Codex login. Try one of: {}{RESET}",
+                    crate::codex_responses::codex_model_list().join(", ")
+                );
+                return Ok(());
+            };
+            canonical.to_string()
+        } else {
+            args.to_string()
+        };
+        state.config.model_override = Some(model_override);
         state.resolve_model();
         println!(
             "  {GREEN}✓{RESET} {DIM}model →{RESET} {CYAN}{}{RESET}",

--- a/src/input.rs
+++ b/src/input.rs
@@ -206,9 +206,23 @@ fn render_input(
         .max()
         .unwrap_or(8)
         .min(18);
-    let shown = matches.len().min(MENU_MAX_ROWS);
+    let start = if matches.len() <= MENU_MAX_ROWS {
+        0
+    } else if sel < MENU_MAX_ROWS {
+        0
+    } else {
+        // Keep the highlighted row inside the visible completion window as the
+        // user arrows down past the first page.
+        sel + 1 - MENU_MAX_ROWS
+    };
+    let shown = (matches.len() - start).min(MENU_MAX_ROWS);
     let mut rows = 0;
-    for (i, (name, desc)) in matches.iter().take(shown).enumerate() {
+    if start > 0 {
+        s.push_str(&format!("\r\n  {MUTED}… {start} above{RESET}"));
+        rows += 1;
+    }
+    for (offset, (name, desc)) in matches.iter().skip(start).take(shown).enumerate() {
+        let i = start + offset;
         s.push_str("\r\n");
         rows += 1;
         // Leave room for: 2 gutter + 2 marker + name_w + 2 gap.
@@ -222,10 +236,10 @@ fn render_input(
             s.push_str(&format!("    {name:<name_w$}  {MUTED}{desc}{RESET}"));
         }
     }
-    if matches.len() > shown {
+    if start + shown < matches.len() {
         s.push_str(&format!(
             "\r\n  {MUTED}… +{} more{RESET}",
-            matches.len() - shown
+            matches.len() - start - shown
         ));
         rows += 1;
     }
@@ -521,6 +535,33 @@ mod tests {
         let out = render_input("> ", 2, &chars, chars.len(), &cmds(), 0, false, 80);
         assert!(!out.contains('▸'));
         assert!(!out.contains("\r\n"));
+    }
+
+    #[test]
+    fn render_completion_window_follows_selected_row() {
+        let commands: Vec<(String, String)> = (0..12)
+            .map(|i| (format!("/cmd{i:02}"), format!("command {i}")))
+            .collect();
+        let chars: Vec<char> = "/".chars().collect();
+        let out = render_input("> ", 2, &chars, chars.len(), &commands, 10, false, 80);
+
+        assert!(
+            out.contains("/cmd10"),
+            "selected row should be visible: {out:?}"
+        );
+        assert!(out.contains("▸"), "selected marker missing: {out:?}");
+        assert!(
+            out.contains("… 3 above"),
+            "top overflow marker missing: {out:?}"
+        );
+        assert!(
+            out.contains("/cmd03"),
+            "window should start near selected row: {out:?}"
+        );
+        assert!(
+            !out.contains("/cmd00"),
+            "first page should scroll out once selection moves below it: {out:?}"
+        );
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,8 @@ mod budget;
 mod cancel;
 mod capabilities;
 mod catalog;
+mod codex_oauth;
+mod codex_responses;
 mod commands;
 mod config;
 mod context_guard;
@@ -46,7 +48,7 @@ use std::io::{IsTerminal, Read, Write};
 
 use crate::app_state::AppState;
 use crate::approval::ApprovalCache;
-use crate::backends::{backend, default_model, validate};
+use crate::backends::{backend, default_model, validate, BackendName};
 use crate::banner::{print_banner, BannerInfo};
 use crate::commands::dispatch;
 use crate::config::load_config;
@@ -343,6 +345,9 @@ async fn probe_backend(
                 crate::backends::BackendName::OpenAi => {
                     "Check OPENAI_API_KEY (or OPENAI_BASE_URL if you're targeting a compatible proxy)."
                 }
+                crate::backends::BackendName::OpenAiCodex => {
+                    "Run `/login openai-codex` to sign in with ChatGPT/Codex."
+                }
             };
             Err(format!("{e}. {hint}"))
         }
@@ -382,9 +387,20 @@ async fn main() -> anyhow::Result<()> {
     let config = load_config();
     let http = crate::openai::build_http_client();
     let backend_desc = backend(config.backend);
+    let missing_codex_login = matches!(config.backend, BackendName::OpenAiCodex)
+        && crate::auth::AuthStore::load()
+            .get_oauth("openai-codex")
+            .is_none();
     if let Err(e) = validate(&backend_desc) {
-        eprintln!("{e}");
-        std::process::exit(1);
+        if missing_codex_login {
+            println!("  {YELLOW}!{RESET} {DIM}{e}{RESET}");
+            println!(
+                "  {DIM}Starting anyway so you can run /login openai-codex, or /backend to switch.{RESET}"
+            );
+        } else {
+            eprintln!("{e}");
+            std::process::exit(1);
+        }
     }
     let model = default_model(&backend_desc, config.model_override.as_deref());
 
@@ -410,7 +426,11 @@ async fn main() -> anyhow::Result<()> {
     }
 
     let mut warmed_fingerprint = None;
-    let probe = probe_backend(&http, &backend_desc).await;
+    let probe = if missing_codex_login {
+        Err("Run /login openai-codex to sign in with ChatGPT/Codex.".to_string())
+    } else {
+        probe_backend(&http, &backend_desc).await
+    };
     if let Err(hint) = probe {
         println!("  {YELLOW}!{RESET} {DIM}Backend not reachable: {hint}{RESET}");
         println!("  {DIM}You can still type /backend to switch, or fix and retry.{RESET}");

--- a/src/openai.rs
+++ b/src/openai.rs
@@ -2,7 +2,7 @@ use anyhow::{anyhow, Result};
 use futures_util::StreamExt;
 use serde::{Deserialize, Serialize};
 
-use crate::backends::BackendDescriptor;
+use crate::backends::{BackendDescriptor, BackendName};
 use crate::cancel::CancellationToken;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -199,6 +199,9 @@ pub async fn list_models(
     client: &reqwest::Client,
     backend: &BackendDescriptor,
 ) -> Result<Vec<String>> {
+    if matches!(backend.name, BackendName::OpenAiCodex) {
+        return Ok(crate::codex_responses::codex_model_list());
+    }
     let url = format!("{}/models", backend.base_url.trim_end_matches('/'));
     let resp = client.get(url).bearer_auth(&backend.api_key).send().await?;
     if !resp.status().is_success() {
@@ -221,6 +224,10 @@ pub async fn chat_oneshot(
     backend: &BackendDescriptor,
     req: &ChatRequest<'_>,
 ) -> Result<()> {
+    if matches!(backend.name, BackendName::OpenAiCodex) {
+        return crate::codex_responses::stream_codex_responses(client, backend, req, None, |_| {})
+            .await;
+    }
     let url = format!(
         "{}/chat/completions",
         backend.base_url.trim_end_matches('/')
@@ -314,6 +321,12 @@ pub async fn stream_chat<F>(
 where
     F: FnMut(StreamChunk),
 {
+    if matches!(backend.name, BackendName::OpenAiCodex) {
+        return crate::codex_responses::stream_codex_responses(
+            client, backend, req, cancel, on_chunk,
+        )
+        .await;
+    }
     let url = format!(
         "{}/chat/completions",
         backend.base_url.trim_end_matches('/')

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -435,6 +435,9 @@ fn backend_hint(backend: BackendName) -> &'static str {
         BackendName::OpenAi => {
             "set `OPENAI_API_KEY` before using the OpenAI backend (optionally `OPENAI_BASE_URL` for a compatible proxy)."
         }
+        BackendName::OpenAiCodex => {
+            "run `/login openai-codex` to sign in with ChatGPT/Codex subscription OAuth."
+        }
     }
 }
 


### PR DESCRIPTION
  ## Summary

   Adds an `openai-codex` backend that lets
 Small Harness use ChatGPT/Codex subscription
 OAuth instead of requiring an OpenAI API key.

   This keeps the existing `openai` API-key
 backend separate from ChatGPT subscription
 auth:

   - `openai` continues to use
 `OPENAI_API_KEY` and `/v1/chat/completions`
   - `openai-codex` uses browser/device OAuth
 and the ChatGPT Codex Responses backend

   ## What changed

   ### Backend support

   - Adds `openai-codex` as a new backend
   - Adds aliases:
     - `codex`
     - `chatgpt`
   - Sets the default Codex OAuth model to
 `gpt-5.5`
   - Aligns the Codex OAuth model list with
 Pi’s current `openai-codex` provider:
     - `gpt-5.5`
     - `gpt-5.4`
     - `gpt-5.4-mini`
     - `gpt-5.3-codex-spark`
   - Adds shorthand model aliases:
     - `5.5` → `gpt-5.5`
     - `5.4` → `gpt-5.4`
     - `5.4-mini` → `gpt-5.4-mini`
     - `spark` → `gpt-5.3-codex-spark`

   ### OAuth login

   - Adds `/login openai-codex`
   - Adds `/logout openai-codex`
   - Adds `/auth login openai-codex`
   - Supports browser OAuth login with a local
 callback server
   - Supports device-code login for
 headless/SSH environments
   - Stores refreshable OAuth credentials in
 `auth.json`
   - Refreshes the OAuth access token before
 use

   ### Auth storage

   - Extends auth storage to support both API
 keys and OAuth credentials
   - Preserves compatibility with legacy auth
 files shaped like:

     ```json
     {
       "openai": "sk-..."
     }
 ```

 - New typed credentials support shapes like:

   ```json
     {
       "openai": {
         "type": "api_key",
         "key": "sk-..."
       },
       "openai-codex": {
         "type": "oauth",
         "access": "...",
         "refresh": "...",
         "expires": 1234567890,
         "accountId": "..."
       }
     }
   ```

 ### Codex Responses adapter

 - Adds a Codex Responses streaming adapter
   for:

   ```text

   https://chatgpt.com/backend-api/codex/respo
   nses
   ```
 - Converts existing ChatMessage/tool
   definitions into Responses-style payloads
 - Maps Responses SSE events back into the
   existing StreamChunk shape so the agent
   loop can remain unchanged
 - Follows Pi’s Codex OAuth request shape,
   including avoiding unsupported parameters
   like max_output_tokens

 ### UX improvements

 - Allows interactive startup to continue if
   BACKEND=openai-codex is configured but the
   user has not logged in yet, so the user can
   run /login openai-codex
 - Updates /auth status output to show
   openai-codex login state
 - Updates /backend and /doctor hints for
   Codex OAuth
 - Fixes slash-command completion scrolling so
   the visible menu follows the selected
   option when navigating past the first page

 Testing

 Automated checks run locally:

 ```bash
   cargo fmt --check
   cargo check
   cargo test
 ```

 Manual smoke tests performed:

 - /login openai-codex
 - /auth
 - /backend openai-codex
 - /model 5.5
 - basic text prompt through ChatGPT/Codex
   OAuth
 - verified unsupported Codex payload
   parameter max_output_tokens is no longer
   sent
 - verified slash-command completion menu
   scrolls with the selected row

 Notes

 This is intentionally implemented as a
 separate backend instead of treating ChatGPT
 subscription auth as an OPENAI_API_KEY
 replacement. OpenAI API billing/key auth and
 ChatGPT subscription OAuth are different
 products and use different request paths.

 ```

   ## If you want a shorter PR description

   Use this instead:

   ```md
   ## Summary

   Adds a new `openai-codex` backend for
 ChatGPT/Codex subscription OAuth.

   This lets users sign in with `/login
 openai-codex` and use Codex via ChatGPT
 OAuth, while keeping the existing `openai`
 backend as the normal `OPENAI_API_KEY` path.

   ## Changes

   - Adds `openai-codex` backend with `codex`
 / `chatgpt` aliases
   - Adds browser OAuth and device-code login
   - Adds `/login openai-codex`, `/logout
 openai-codex`, and `/auth login openai-codex`
   - Extends `auth.json` to support typed
 API-key and OAuth credentials while
 preserving legacy API-key files
   - Adds token refresh before Codex requests
   - Adds a Codex Responses adapter for
 `chatgpt.com/backend-api/codex/responses`
   - Aligns Codex OAuth model defaults/list
 with Pi:
     - `gpt-5.5`
     - `gpt-5.4`
     - `gpt-5.4-mini`
     - `gpt-5.3-codex-spark`
   - Adds shorthand aliases like `/model 5.5`
 → `gpt-5.5`
   - Fixes slash-command completion scrolling

   ## Testing

   ```bash
   cargo fmt --check
   cargo check
   cargo test
 ```

 Manual smoke tested:

 - /login openai-codex
 - /backend openai-codex
 - /model 5.5
 - basic Codex OAuth text prompt