### PR TITLE
fix: prevent spurious response headers when streaming thinking-model tokens

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -285,7 +285,7 @@ where
                     if was_empty && looks_like_start_of_tool_call(&assistant_text) {
                         buffering_inline = true;
                     }
-                    if !buffering_inline {
+                    if !buffering_inline && !content.is_empty() {
                         on_event(AgentEvent::Text {
                             delta: content.clone(),
                         });

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -375,7 +375,9 @@ impl TuiRenderer {
                 ..
             } => self.render_compaction_notice(&name, &summary, depth),
             AgentEvent::Reasoning { delta } => {
-                self.end_answer();
+                if self.display.reasoning {
+                    self.end_answer();
+                }
                 self.render_reasoning(&delta)
             }
             AgentEvent::ContextCompacted { notice, .. } => {
@@ -435,6 +437,9 @@ impl TuiRenderer {
     }
 
     fn render_text(&mut self, delta: &str) {
+        if delta.is_empty() {
+            return;
+        }
         self.flush_minimal();
         // Switching from reasoning to answer text — close the panel cleanly
         // so the answer doesn't appear glued to the dim trace.
@@ -801,5 +806,81 @@ mod verbose_tests {
         r.set_verbose(false);
         assert!(!r.verbose_enabled());
         assert!(matches!(r.display.tool_display, ToolDisplay::Grouped));
+    }
+}
+
+#[cfg(test)]
+mod thinking_model_tests {
+    use super::*;
+    use crate::agent::AgentEvent;
+    use crate::config::DisplayConfig;
+
+    fn renderer_reasoning_off() -> TuiRenderer {
+        let mut cfg = DisplayConfig::default();
+        cfg.reasoning = false;
+        TuiRenderer::new(cfg)
+    }
+
+    fn renderer_reasoning_on() -> TuiRenderer {
+        let mut cfg = DisplayConfig::default();
+        cfg.reasoning = true;
+        TuiRenderer::new(cfg)
+    }
+
+    /// Thinking models (qwen3, deepseek-r1) emit empty `content` strings
+    /// alongside each `reasoning` token. An empty Text event must not open
+    /// a new response block — that was the root cause of the per-word rendering
+    /// bug (#thinking-model-response-headers).
+    #[test]
+    fn empty_text_delta_does_not_open_answer_block() {
+        let mut r = renderer_reasoning_off();
+        assert!(r.answer_wrap.is_none());
+        r.handle(AgentEvent::Text {
+            delta: String::new(),
+        });
+        assert!(
+            r.answer_wrap.is_none(),
+            "empty Text delta must not open an answer_wrap block"
+        );
+    }
+
+    /// When reasoning display is OFF, a Reasoning event must not close the
+    /// current answer block. Before the fix, `end_answer()` was called
+    /// unconditionally, destroying the in-progress response on every
+    /// reasoning token.
+    #[test]
+    fn reasoning_event_preserves_answer_block_when_reasoning_display_off() {
+        let mut r = renderer_reasoning_off();
+        // Open an answer block by sending real text.
+        r.handle(AgentEvent::Text {
+            delta: "hello".to_string(),
+        });
+        assert!(r.answer_wrap.is_some(), "setup: answer_wrap should be open");
+        // Reasoning event should NOT close it when reasoning=false.
+        r.handle(AgentEvent::Reasoning {
+            delta: "thinking...".to_string(),
+        });
+        assert!(
+            r.answer_wrap.is_some(),
+            "answer_wrap must survive a Reasoning event when reasoning display is off"
+        );
+    }
+
+    /// When reasoning display is ON, a Reasoning event closes the answer block
+    /// (to print the reasoning panel). This is the intended behaviour.
+    #[test]
+    fn reasoning_event_closes_answer_block_when_reasoning_display_on() {
+        let mut r = renderer_reasoning_on();
+        r.handle(AgentEvent::Text {
+            delta: "hello".to_string(),
+        });
+        assert!(r.answer_wrap.is_some(), "setup: answer_wrap should be open");
+        r.handle(AgentEvent::Reasoning {
+            delta: "thinking...".to_string(),
+        });
+        assert!(
+            r.answer_wrap.is_none(),
+            "answer_wrap should be closed when reasoning display is on"
+        );
     }
 }

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -816,14 +816,18 @@ mod thinking_model_tests {
     use crate::config::DisplayConfig;
 
     fn renderer_reasoning_off() -> TuiRenderer {
-        let mut cfg = DisplayConfig::default();
-        cfg.reasoning = false;
+        let cfg = DisplayConfig {
+            reasoning: false,
+            ..Default::default()
+        };
         TuiRenderer::new(cfg)
     }
 
     fn renderer_reasoning_on() -> TuiRenderer {
-        let mut cfg = DisplayConfig::default();
-        cfg.reasoning = true;
+        let cfg = DisplayConfig {
+            reasoning: true,
+            ..Default::default()
+        };
         TuiRenderer::new(cfg)
     }
 


### PR DESCRIPTION
## Problem

When using a thinking/reasoning model (qwen3, deepseek-r1, etc.) via Ollama, the interactive TUI renders a new `response ──` header for every individual reasoning token — producing hundreds of blank panels and making the session unusable.

**Root cause:** Two independent bugs that compound each other:

1. **`agent.rs`** — The streaming loop emits `AgentEvent::Text` for every `content` delta, including the empty strings (`""`) that Ollama sends alongside each `reasoning` token during the thinking phase. `render_text("")` opens a fresh answer panel (printing a new header) even though there is nothing to render.

2. **`renderer.rs`** — The `Reasoning` event handler calls `end_answer()` unconditionally, closing whichever answer panel was just opened. This leaves `answer_wrap = None`, so the next empty `Text` delta opens yet another panel. With hundreds of thinking tokens, this cycle produces hundreds of spurious headers — even when `display.reasoning` is `false`.

## Fix

Three minimal changes:

- **`agent.rs` (1 line):** Skip `AgentEvent::Text` emission when the content delta is empty.
- **`renderer.rs` (3 lines):** Only call `end_answer()` in the `Reasoning` handler when `display.reasoning` is `true`; when reasoning display is off, the answer panel should be unaffected by reasoning tokens.
- **`renderer.rs` (3 lines):** Guard `render_text()` with an early return on empty delta as defence-in-depth against future empty deltas from any backend.

## Tests

Three unit tests added to `renderer.rs`:

- `empty_text_delta_does_not_open_answer_block` — empty `Text` event leaves `answer_wrap` as `None`
- `reasoning_event_preserves_answer_block_when_reasoning_display_off` — `Reasoning` event does not close an in-progress answer when `reasoning: false`
- `reasoning_event_closes_answer_block_when_reasoning_display_on` — `Reasoning` event correctly closes the answer block when `reasoning: true` (existing intended behaviour)

All 383 existing tests continue to pass.

## Verified with

- qwen3:8b via Ollama 0.30.8 on an RTX 2080 Super (SM 75)
- qwen2.5:7b via Ollama 0.30.8 (baseline — no thinking tokens, unaffected)