### PR TITLE
fix: change default Ollama model to qwen2.5:7b (coder variant breaks tool calls)

### DIFF
--- a/src/backends.rs
+++ b/src/backends.rs
@@ -140,7 +140,12 @@ pub fn default_model(b: &BackendDescriptor, override_: Option<&str>) -> String {
         return m.to_string();
     }
     match b.name {
-        BackendName::Ollama => "qwen2.5-coder:7b",
+        // qwen2.5:7b (base) is used rather than qwen2.5-coder:7b because the
+        // coder variant does not use Ollama's structured tool_calls API —
+        // it emits tool invocations as raw JSON text in the content field,
+        // which SmallHarness cannot execute. The base model uses the same
+        // <tool_call> template that Ollama translates to structured tool_calls.
+        BackendName::Ollama => "qwen2.5:7b",
         BackendName::LmStudio => "qwen2.5-coder-7b-instruct",
         BackendName::Mlx => "mlx-community/Qwen2.5-Coder-7B-Instruct-4bit",
         BackendName::LlamaCpp => "gpt-3.5-turbo",
@@ -230,6 +235,20 @@ mod tests {
     fn defaults_openai_to_gpt_4o_mini() {
         let model = default_model(&descriptor(BackendName::OpenAi), None);
         assert_eq!(model, "gpt-4o-mini");
+    }
+
+    #[test]
+    fn defaults_ollama_to_base_qwen_not_coder_variant() {
+        // qwen2.5:7b (base) must be the default, not qwen2.5-coder:7b.
+        // The coder variant emits tool calls as raw JSON text rather than
+        // via Ollama's structured tool_calls API, so SmallHarness cannot
+        // execute them in interactive or one-shot mode.
+        let model = default_model(&descriptor(BackendName::Ollama), None);
+        assert_eq!(model, "qwen2.5:7b");
+        assert_ne!(
+            model, "qwen2.5-coder:7b",
+            "coder variant does not support structured tool_calls"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Problem

The default Ollama model `qwen2.5-coder:7b` does not use Ollama's structured `tool_calls` API. When SmallHarness sends tool definitions with a request, the coder variant emits tool invocations as raw JSON text inside the `content` field:

```json
{"name": "shell", "arguments": {"command": "ls"}}
```

SmallHarness reads tool calls from the `tool_calls` array in the API response, not from response text. These invocations are never executed — the session displays them as prose and stalls, with no error message to explain why.

This is the first thing a new Ollama user hits, and there's no indication of what's wrong.

## Fix

Change the default from `qwen2.5-coder:7b` to `qwen2.5:7b`.

The base model uses the `<tool_call>` XML template that Ollama correctly translates into structured `tool_calls` responses. Tool calls from the base model are received and executed as expected in both interactive and one-shot (`--print`) modes.

Users who specifically want the coder fine-tune can set `modelOverride` in `agent.config.json`. The coder variant is a fine coding model — it just cannot reliably invoke tools, which is a prerequisite for an interactive coding agent.

## Test

Added `defaults_ollama_to_base_qwen_not_coder_variant` which asserts the default is `qwen2.5:7b` and explicitly rejects `qwen2.5-coder:7b` with a comment explaining why.

All 384 tests pass.

## Verified with

Ollama 0.30.8, both `qwen2.5:7b` and `qwen2.5-coder:7b` pulled locally. The base model calls tools correctly; the coder variant emits raw JSON text.