### PR TITLE
docs: update README version badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 <p align="center">
   <a href="https://github.com/GetSmallAI/SmallHarness/actions/workflows/ci.yml"><img alt="CI" src="https://github.com/GetSmallAI/SmallHarness/actions/workflows/ci.yml/badge.svg"></a>
   <img alt="Rust" src="https://img.shields.io/badge/Rust-1.75%2B-dea584">
-  <img alt="Version" src="https://img.shields.io/badge/version-1.0.3-111827">
+  <img alt="Version" src="https://img.shields.io/badge/version-1.0.4-111827">
   <img alt="Backends" src="https://img.shields.io/badge/backends-Ollama%20%7C%20LM%20Studio%20%7C%20MLX%20%7C%20llama.cpp%20%7C%20OpenRouter%20%7C%20OpenAI-2563eb">
   <img alt="Apple Silicon" src="https://img.shields.io/badge/Apple%20Silicon-optimized-111827">
   <img alt="License MIT" src="https://img.shields.io/badge/license-MIT-111827">


### PR DESCRIPTION
## Summary
- update the README version badge from 1.0.3 to 1.0.4
- align the badge with Cargo.toml and the latest release tag

## Testing
- git diff --check
- rg -n "version-1\.0\.[34]|version = \"1\.0\.4\"" README.md Cargo.toml CHANGELOG.md

Note: full Rust checks were not run locally because cargo is not installed in this environment; this is a docs-only badge update.