### PR TITLE
feat: visual polish — streamed markdown, colored diffs, theming, NO_COLOR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,34 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [1.2.0] - 2026-07-08
+
 ### Added
 
+- **Complexity-aware plan routing.** `/plan route <intent>` can now ask a
+  configured planning model to break a larger request into low-, medium-, and
+  high-complexity tasks, persist the plan to `.small-harness/plan.json`, and
+  route each ready task through the configured execution tier. `/plan status`
+  shows task progress, and `/plan execute` runs ready tasks sequentially while
+  switching models for each task.
+- **Model-system planner tier.** `agent.config.json` can now define
+  `modelSystem.planner` alongside selector and execution models, making it
+  possible to plan with a subscription-backed or API-backed frontier model and
+  execute subtasks across cheaper, local, or specialized models.
 - **Claude Fable usage tracker.** `/fable` now shows weekly Small
   Harness-tracked Fable tokens, turns, share of tracked Claude-family usage,
   and optional remaining allowance for plans where Fable is capped to a share
   of weekly usage. Fable turns also append a compact weekly tracker to the
   footer.
+- **Terminal visual polish.** The interactive UI now has streamed markdown
+  styling, code-block framing, colored diffs, theme handling, a gradient
+  banner, and `NO_COLOR`-aware output for cleaner long-running sessions.
+
+### Fixed
+
+- **Dependency audit.** Updated `quinn-proto` and `crossbeam-epoch` to versions
+  that clear the current RustSec audit failures while preserving the existing
+  allowed `anyhow` warning policy.
 
 ## [1.1.1] - 2026-07-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+
+- **Claude Fable usage tracker.** `/fable` now shows weekly Small
+  Harness-tracked Fable tokens, turns, share of tracked Claude-family usage,
+  and optional remaining allowance for plans where Fable is capped to a share
+  of weekly usage. Fable turns also append a compact weekly tracker to the
+  footer.
+
 ## [1.1.1] - 2026-07-02
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -152,9 +152,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -799,9 +799,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1174,7 +1174,7 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "small-harness"
-version = "1.1.1"
+version = "1.2.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "small-harness"
-version = "1.1.1"
+version = "1.2.0"
 edition = "2021"
 description = "Terminal-based agent harness for running small LLMs on your Mac"
 license = "MIT"

--- a/Quickstart.md
+++ b/Quickstart.md
@@ -147,6 +147,7 @@ Useful commands:
 /scorecard close "OAuth login PR" --url https://github.com/org/repo/pull/42
 /scorecard doctor   inspect the local scorecard ledger
 /scorecard export   copy the raw scorecard JSONL before repair or sharing
+/fable       show Claude Fable weekly usage and cap headroom
 /handoff      draft commit, changelog, testing, and X-ready release copy
 /fusion on    switch to OpenRouter Fusion for deliberative coding questions
 /fusion tool  attach Fusion deliberation to an OpenRouter coding model

--- a/README.md
+++ b/README.md
@@ -47,6 +47,10 @@ few that aren't usual:
 - **Multi-model routing.** `/route select <task>` asks a configured selector
   model to pick low/medium/high orchestrator and coder tiers, plus play vs
   production review and security review, then switches the active coding model.
+- **Routed plans.** `/plan route <goal>` asks a configured planner model to
+  break work into a low/medium/high task graph, saves it to
+  `.small-harness/plan.json`, and `/plan execute` runs ready tasks through the
+  configured coder tiers.
 - **Real undo.** `/undo` reverts the last agent turn's file mutations,
   including files the agent created or files that weren't tracked when the
   turn started.
@@ -320,6 +324,9 @@ this exact call`. The session cache resets on `/new`.
 ```
 /mode explore|edit|ship|review   switch operator preset
 /plan <intent>                   expand a short intent into a spec (.small-harness/spec.md)
+/plan route <intent>             create a low/medium/high routed execution plan
+/plan status                     show .small-harness/plan.json task status
+/plan execute [--yolo] [--max N] run ready routed-plan tasks
 /plan validate                   check the spec's Done Criteria against the working diff
 /shipcheck                       summarize git + test readiness
 /ship [--tests]                  preview last-mile ship readiness and commit message
@@ -511,6 +518,30 @@ global quality PR scorecard.
 `.small-harness/spec.md`. It deliberately stays at the level of *what* and
 *why*, not implementation, so an early spec doesn't lock in the wrong details.
 `/plan show` prints the saved spec; `--export <path>` writes elsewhere.
+
+`/plan route <intent>` is the complexity-aware execution-layer path. It uses
+`modelSystem.planner` when configured (falling back to selector, high/medium/low
+orchestrator, then the active model), asks for a JSON task graph, assigns each
+node to `modelSystem.coders.low|medium|high`, and writes
+`.small-harness/plan.json`. Use `--planner high`, `--planner selector`, or
+`--planner backend:model-id` to override the planner for one route:
+
+```text
+/plan route --planner high add OAuth login with refresh and tests
+/plan status
+/plan execute --max 2
+```
+
+`/plan execute` runs ready tasks sequentially, switching the active backend/model
+per task and saving status after each node. `--yolo` auto-approves tools for
+unattended local execution.
+
+To mix subscription and API usage, put subscription-backed models on tiers where
+Small Harness has a real login backend, such as `openai-codex` after
+`/login openai-codex`, and keep usage-billed automation on `openai`,
+`openrouter`, or local backends. For Claude/Fable subscriptions, track usage
+with `/fable`; direct unattended execution should stay on an API-compatible
+backend unless you add an explicit Claude CLI adapter.
 
 `/plan validate` closes the loop: it reads the spec's **Done Criteria** and
 checks each one against the current working-tree diff (the same done-check
@@ -844,6 +875,10 @@ active session effort, appears in `/session` and the turn footer, and is sent to
 OpenRouter as `reasoning.effort`; local backends ignore unsupported request
 fields while still showing the selected effort.
 
+For whole-goal decomposition, `/plan route <goal>` uses `modelSystem.planner`
+or a planner override to create `.small-harness/plan.json`; `/plan execute`
+then runs each ready node with the configured low/medium/high coder model.
+
 ---
 
 ## Configuration
@@ -942,6 +977,12 @@ root. Common shape:
   },
   "modelSystem": {
     "enabled": true,
+    "planner": {
+      "backend": "openrouter",
+      "model": "anthropic/claude-opus-4.8",
+      "effort": "high",
+      "thinkingDepth": "deep"
+    },
     "selector": {
       "backend": "openrouter",
       "model": "openrouter/fusion",

--- a/README.md
+++ b/README.md
@@ -335,6 +335,7 @@ this exact call`. The session cache resets on `/new`.
 /scorecard close <label> [--url <url>] [--tests]  close branch with shipcheck quality score
 /scorecard doctor                inspect the local scorecard ledger for malformed JSONL
 /scorecard export [path]          copy the raw scorecard ledger before repair or sharing
+/fable                           show Claude Fable weekly usage and cap headroom
 /handoff                         draft commit, changelog, release copy
 /test discover|run|smart         discover or run tests
 /fix                             fix-until-green loop
@@ -429,6 +430,30 @@ The `/model` picker shows the same data while you choose:
    2) gpt-4o                 128k ctx · $2.50/$10.00 per Mtoken
    3) o1-mini                128k ctx · $3.00/$12.00 per Mtoken
 ```
+
+### Claude Fable tracker
+
+`/fable` rolls up the local turn ledger into a weekly Claude Fable tracker:
+Fable tokens, Fable turns, Fable's share of tracked Claude-family usage, and
+remaining allowance when you configure a weekly plan budget. Fable turns also
+append a compact weekly tracker to the status footer.
+
+By default, Fable models are detected by model IDs containing `fable`, and the
+cap share is `0.5` (50%). Add this to `agent.config.json` when you know the
+weekly Claude-plan token budget you want Small Harness to monitor:
+
+```json
+{
+  "fable": {
+    "weeklyTokenBudget": 200000,
+    "capShare": 0.5,
+    "weekStartsOn": "monday"
+  }
+}
+```
+
+The tracker only sees Small Harness turns recorded in the local ledger. It
+cannot see usage from the Claude app or other clients.
 
 ### Quality PR scorecard
 
@@ -876,6 +901,12 @@ root. Common shape:
     "enabled": true,
     "qualityThreshold": 80,
     "nudgeMinTurns": 3
+  },
+  "fable": {
+    "enabled": true,
+    "weeklyTokenBudget": null,
+    "capShare": 0.5,
+    "weekStartsOn": "monday"
   },
   "workspaceRoot": "/path/to/project",
   "outsideWorkspace": "prompt",

--- a/src/approval.rs
+++ b/src/approval.rs
@@ -84,12 +84,7 @@ impl ApprovalProvider for ApprovalCache {
             }
             if let Some(diff) = &preview.diff {
                 println!();
-                for line in diff.lines().take(80) {
-                    println!("    {DIM}{line}{RESET}");
-                }
-                if diff.lines().count() > 80 {
-                    println!("    {DIM}…diff truncated for display{RESET}");
-                }
+                crate::diff_view::print_diff(diff, 80);
                 println!();
             }
         }

--- a/src/approval.rs
+++ b/src/approval.rs
@@ -6,12 +6,14 @@ use crate::agent::ApprovalProvider;
 use crate::input::plain_read_line;
 use crate::tools::ToolPreview;
 
-const RESET: &str = "\x1b[0m";
-const BOLD: &str = "\x1b[1m";
-const DIM: &str = "\x1b[2m";
-const YELLOW: &str = "\x1b[33m";
-const RED: &str = "\x1b[31m";
-const GREEN: &str = "\x1b[32m";
+use crate::theme::{FAIL, OK, WARN_MARK};
+
+const RESET: crate::theme::Style = crate::theme::RESET;
+const BOLD: crate::theme::Style = crate::theme::BOLD;
+const DIM: crate::theme::Style = crate::theme::MUTED;
+const YELLOW: crate::theme::Style = crate::theme::WARN;
+const RED: crate::theme::Style = crate::theme::ERROR;
+const GREEN: crate::theme::Style = crate::theme::SUCCESS;
 
 pub struct ApprovalCache {
     pub always_allow: HashSet<String>,
@@ -73,7 +75,7 @@ impl ApprovalProvider for ApprovalCache {
             .unwrap_or_else(|| summarize(name, args));
         println!();
         println!(
-            "  {YELLOW}▲{RESET} {BOLD}Approval required{RESET} {DIM}for{RESET} {BOLD}{name}{RESET}"
+            "  {YELLOW}{WARN_MARK}{RESET} {BOLD}Approval required{RESET} {DIM}for{RESET} {BOLD}{name}{RESET}"
         );
         println!("    {DIM}{summary}{RESET}");
         if let Some(preview) = preview {
@@ -102,7 +104,7 @@ impl ApprovalProvider for ApprovalCache {
 
         if answer == "a" || answer == "always" {
             self.always_allow.insert(name.to_string());
-            println!("  {GREEN}✓{RESET} {DIM}allowing all {name} calls this session{RESET}");
+            println!("  {GREEN}{OK}{RESET} {DIM}allowing all {name} calls this session{RESET}");
             return true;
         }
         if answer == "s" {
@@ -112,7 +114,7 @@ impl ApprovalProvider for ApprovalCache {
         if answer == "y" || answer == "yes" {
             return true;
         }
-        println!("  {RED}✗{RESET} {DIM}denied{RESET}");
+        println!("  {RED}{FAIL}{RESET} {DIM}denied{RESET}");
         false
     }
 }

--- a/src/auto_loop.rs
+++ b/src/auto_loop.rs
@@ -38,12 +38,12 @@ use crate::planner::default_spec_path;
 use crate::session_turn::{run_user_turn, TurnOptions};
 use crate::tools::run_evaluation;
 
-const RESET: &str = "\x1b[0m";
-const DIM: &str = "\x1b[2m";
-const GREEN: &str = "\x1b[32m";
-const RED: &str = "\x1b[31m";
-const YELLOW: &str = "\x1b[33m";
-const CYAN: &str = "\x1b[36m";
+const RESET: crate::theme::Style = crate::theme::RESET;
+const DIM: crate::theme::Style = crate::theme::MUTED;
+const GREEN: crate::theme::Style = crate::theme::SUCCESS;
+const RED: crate::theme::Style = crate::theme::ERROR;
+const YELLOW: crate::theme::Style = crate::theme::WARN;
+const CYAN: crate::theme::Style = crate::theme::ACCENT;
 
 /// Hard upper bound on rounds regardless of config/flags — a runaway guard for
 /// an unattended loop. Higher than `/iterate`'s ceiling because overnight runs

--- a/src/banner.rs
+++ b/src/banner.rs
@@ -1,4 +1,4 @@
-use crate::theme::{rule, ACCENT, ACCENT_DEEP, BOLD, MUTED, PAD, RESET};
+use crate::theme::{colors_enabled, rule, ACCENT, ACCENT_DEEP, BOLD, FADE_RAMP, MUTED, PAD, RESET};
 
 const LOGO: &str = r"   ███████╗███╗   ███╗ █████╗ ██╗     ██╗
    ██╔════╝████╗ ████║██╔══██╗██║     ██║
@@ -24,14 +24,38 @@ fn row(label: &str, value: &str) -> String {
     format!("{PAD}{MUTED}{label:<9}{RESET}{ACCENT}{value}{RESET}")
 }
 
+/// The logo, colored per-line across the cyan segment of the shared fade
+/// ramp (the ramp's gray tail is reserved for the trailing-off `fade_header`
+/// rule and would make the bottom logo rows illegible here). Falls back to
+/// the previous flat `ACCENT_DEEP` when colors are disabled.
+fn gradient_logo() -> String {
+    if !colors_enabled() {
+        return format!("{ACCENT_DEEP}{BOLD}{LOGO}{RESET}");
+    }
+    // Cyan-to-teal half of the ramp only (51 → 23); the gray tail (indices
+    // 9..=11) is deliberately excluded here.
+    const CYAN_SEGMENT_END: usize = 8;
+    let lines: Vec<&str> = LOGO.lines().collect();
+    let last = lines.len().saturating_sub(1).max(1);
+    let mut out = String::new();
+    for (i, line) in lines.iter().enumerate() {
+        let idx = (i * CYAN_SEGMENT_END) / last;
+        out.push_str(&format!(
+            "{BOLD}\x1b[38;5;{}m{line}{RESET}\n",
+            FADE_RAMP[idx]
+        ));
+    }
+    out
+}
+
 pub fn print_banner(info: BannerInfo<'_>) {
     println!();
-    println!("{ACCENT_DEEP}{BOLD}{LOGO}{RESET}");
+    print!("{}", gradient_logo());
     println!();
     println!(
-        "{PAD}{BOLD}Small Harness{RESET}  {MUTED}— a small, terminal-first coding harness{RESET}"
+        "{PAD}{BOLD}Small Harness v{}{RESET}  {MUTED}— a small, terminal-first coding harness{RESET}",
+        env!("CARGO_PKG_VERSION")
     );
-    println!();
     println!("{}", row("backend", info.backend));
     println!("{}", row("model", info.model));
     println!("{}", row("approval", info.approval));
@@ -39,5 +63,47 @@ pub fn print_banner(info: BannerInfo<'_>) {
     println!(
         "{PAD}{MUTED}/help{RESET} commands  {MUTED}·{RESET}  {MUTED}/backend /model{RESET} switch  {MUTED}·{RESET}  {MUTED}/exit{RESET} quit"
     );
-    println!();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    // gradient_logo() reads a process-global color switch; serialize the two
+    // color-mode tests so they don't race with each other or with theme.rs's
+    // own switch-flipping test.
+    static COLOR_SWITCH_TEST_LOCK: Mutex<()> = Mutex::new(());
+
+    fn with_colors(enabled: bool, f: impl FnOnce()) {
+        let _guard = COLOR_SWITCH_TEST_LOCK.lock().unwrap();
+        crate::theme::init(
+            if enabled {
+                crate::config::ColorMode::Always
+            } else {
+                crate::config::ColorMode::Never
+            },
+            false,
+        );
+        f();
+        crate::theme::init(crate::config::ColorMode::Always, false);
+    }
+
+    #[test]
+    fn gradient_logo_has_no_escapes_when_colors_disabled() {
+        with_colors(false, || {
+            let logo = gradient_logo();
+            assert!(!logo.contains('\x1b'));
+            assert!(logo.contains("███████╗")); // still the same art, just uncolored
+        });
+    }
+
+    #[test]
+    fn gradient_logo_colors_every_line_when_enabled() {
+        with_colors(true, || {
+            let logo = gradient_logo();
+            let line_count = LOGO.lines().count();
+            assert_eq!(logo.matches("\x1b[38;5;").count(), line_count);
+        });
+    }
 }

--- a/src/commands/fable.rs
+++ b/src/commands/fable.rs
@@ -1,0 +1,43 @@
+use anyhow::Result;
+
+use crate::app_state::AppState;
+
+const RESET: crate::theme::Style = crate::theme::RESET;
+const DIM: crate::theme::Style = crate::theme::MUTED;
+const YELLOW: crate::theme::Style = crate::theme::WARN;
+
+pub(super) fn cmd_fable(args: &str, state: &AppState) -> Result<()> {
+    let mut parts = args.split_whitespace();
+    let action = parts.next().unwrap_or("show");
+
+    match action {
+        "" | "show" | "usage" | "current" => {
+            if !state.config.fable.enabled {
+                println!("  {DIM}Fable tracker disabled in config (fable.enabled = false){RESET}");
+                return Ok(());
+            }
+            let report = crate::fable_usage::load_report(&state.config.fable)?;
+            print!(
+                "{}",
+                crate::fable_usage::render_report(&report, state.config.scorecard.enabled)
+            );
+        }
+        "path" => match crate::scorecard::scorecard_path() {
+            Some(path) => println!("  {DIM}fableStore{RESET} {}", path.display()),
+            None => println!(
+                "  {YELLOW}!{RESET} {DIM}Fable tracker store unavailable: HOME is unset{RESET}"
+            ),
+        },
+        "help" => print_fable_usage(),
+        _ => print_fable_usage(),
+    }
+
+    Ok(())
+}
+
+fn print_fable_usage() {
+    println!("  {DIM}Usage: /fable [show|usage|current|path|help]{RESET}");
+    println!(
+        "  {DIM}Tracks Small Harness turns whose model id matches fable.fableModelMatches (default: `fable`).{RESET}"
+    );
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -97,13 +97,13 @@ use doctor::*;
 use ship::*;
 use workflow::*;
 
-const RESET: &str = "\x1b[0m";
-const DIM: &str = "\x1b[2m";
-const BOLD: &str = "\x1b[1m";
-const CYAN: &str = "\x1b[36m";
-const GREEN: &str = "\x1b[32m";
-const YELLOW: &str = "\x1b[33m";
-const RED: &str = "\x1b[31m";
+const RESET: crate::theme::Style = crate::theme::RESET;
+const DIM: crate::theme::Style = crate::theme::MUTED;
+const BOLD: crate::theme::Style = crate::theme::BOLD;
+const CYAN: crate::theme::Style = crate::theme::ACCENT;
+const GREEN: crate::theme::Style = crate::theme::SUCCESS;
+const YELLOW: crate::theme::Style = crate::theme::WARN;
+const RED: crate::theme::Style = crate::theme::ERROR;
 
 pub const COMMANDS: &[(&str, &str)] = &[
     ("/undo", "Revert the last agent turn's file mutations"),

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -83,6 +83,7 @@ use crate::warmup::warmup;
 mod config_cmds;
 mod context_cmds;
 mod doctor;
+mod fable;
 mod hooks_cmds;
 mod memory;
 mod route;
@@ -145,6 +146,10 @@ pub const COMMANDS: &[(&str, &str)] = &[
     (
         "/scorecard",
         "Show global quality PRs shipped and close PR units",
+    ),
+    (
+        "/fable",
+        "Track Claude Fable weekly usage and cap headroom",
     ),
     ("/sessions", "List saved sessions"),
     ("/resume", "Resume latest or named session"),
@@ -271,6 +276,7 @@ pub async fn dispatch(input: &str, state: &mut AppState) -> Result<()> {
         "/plan" => cmd_plan(&args, state).await?,
         "/session" => session::cmd_session(&args, state)?,
         "/scorecard" => scorecard::cmd_scorecard(&args, state)?,
+        "/fable" => fable::cmd_fable(&args, state)?,
         "/sessions" => session::cmd_sessions(&args, state)?,
         "/resume" => session::cmd_resume(&args, state)?,
         "/export" => session::cmd_export(&args, state)?,

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -40,12 +40,15 @@ use crate::handoff::{
 use crate::hardware::{detect_hardware_spec, save_hardware_summary, HardwareSpec};
 use crate::input::plain_read_line;
 use crate::iterate_loop::{collect_diff_context, parse_iterate_args, run_iterate_loop};
+use crate::model_system::{EffortLevel, ModelRef, TaskComplexity};
 use crate::openai::{
     list_models, stream_chat, ChatMessage, ChatRequest, StreamOptions, ToolDef, ToolDefFunction,
 };
 use crate::planner::{
-    default_spec_path, ensure_spec_sections, planner_system_prompt, render_fallback_spec,
-    render_planner_prompt,
+    default_routed_plan_path, default_spec_path, ensure_spec_sections, load_routed_plan,
+    parse_routed_plan, planner_system_prompt, render_fallback_spec, render_planner_prompt,
+    render_routed_planner_prompt, routed_planner_system_prompt, save_routed_plan, PlanTaskStatus,
+    RoutedPlan, RoutedPlanTask,
 };
 use crate::playground::{
     print_play_list, print_scorecard, restore_play_session, run_play_battle, run_play_fixture,
@@ -68,6 +71,7 @@ use crate::session::{
     set_session_title, SessionEntry,
 };
 use crate::session_paths::{apply_path_session_state, PathStore, DEFAULT_PATH_ID};
+use crate::session_turn::{run_user_turn, TurnOptions};
 use crate::shipcheck::{
     collect_shipcheck, collect_shipcheck_with_tests, default_export_path, file_status_label,
     render_markdown as render_shipcheck_markdown, ShipcheckSnapshot,
@@ -140,7 +144,7 @@ pub const COMMANDS: &[(&str, &str)] = &[
     ),
     (
         "/plan",
-        "Expand a short intent into a product spec; /plan validate checks its Done Criteria against the diff",
+        "Expand a spec, create routed task graphs, execute routed plans, or validate Done Criteria",
     ),
     ("/session", "Show session info and token usage"),
     (
@@ -583,10 +587,32 @@ async fn cmd_handoff(args: &str, state: &AppState) -> Result<()> {
 enum PlanInvocation {
     Show,
     Validate,
+    Status,
+    Route {
+        intent: String,
+        export_path: Option<PathBuf>,
+        planner: Option<PlannerChoice>,
+    },
+    Execute(PlanExecuteArgs),
     Draft {
         intent: String,
         export_path: Option<PathBuf>,
     },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum PlannerChoice {
+    Configured,
+    Selector,
+    Tier(TaskComplexity),
+    Active,
+    Explicit(ModelRef),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct PlanExecuteArgs {
+    yolo: bool,
+    max_tasks: Option<usize>,
 }
 
 /// Parse `/plan` arguments. Returns `None` to print usage.
@@ -594,6 +620,9 @@ enum PlanInvocation {
 ///   `/plan <intent> --export <path>` → draft to `<path>` instead
 ///   `/plan show`                     → print the saved spec
 ///   `/plan validate`                 → check the spec's Done Criteria vs the diff
+///   `/plan route <intent>`           → draft `.small-harness/plan.json`
+///   `/plan status`                   → show routed plan status
+///   `/plan execute`                  → execute ready routed-plan tasks
 fn parse_plan_args(args: &str) -> Option<PlanInvocation> {
     let trimmed = args.trim();
     if trimmed.is_empty() {
@@ -604,6 +633,24 @@ fn parse_plan_args(args: &str) -> Option<PlanInvocation> {
     }
     if trimmed == "validate" {
         return Some(PlanInvocation::Validate);
+    }
+    if matches!(trimmed, "status" | "route status" | "routed status") {
+        return Some(PlanInvocation::Status);
+    }
+    if let Some(rest) = trimmed
+        .strip_prefix("route ")
+        .or_else(|| trimmed.strip_prefix("routed "))
+    {
+        return parse_plan_route_args(rest.trim());
+    }
+    if matches!(trimmed, "route" | "routed") {
+        return None;
+    }
+    if let Some(rest) = trimmed
+        .strip_prefix("execute")
+        .or_else(|| trimmed.strip_prefix("run"))
+    {
+        return parse_plan_execute_args(rest.trim()).map(PlanInvocation::Execute);
     }
 
     let mut export_path: Option<PathBuf> = None;
@@ -632,15 +679,89 @@ fn parse_plan_args(args: &str) -> Option<PlanInvocation> {
     })
 }
 
-async fn cmd_plan(args: &str, state: &AppState) -> Result<()> {
+fn parse_plan_route_args(rest: &str) -> Option<PlanInvocation> {
+    if rest.is_empty() {
+        return None;
+    }
+    let mut export_path: Option<PathBuf> = None;
+    let mut planner: Option<PlannerChoice> = None;
+    let mut intent_parts: Vec<&str> = Vec::new();
+    let mut parts = rest.split_whitespace();
+    while let Some(part) = parts.next() {
+        if part == "--export" {
+            export_path = Some(PathBuf::from(parts.next()?));
+        } else if let Some(value) = part.strip_prefix("--export=") {
+            if value.is_empty() {
+                return None;
+            }
+            export_path = Some(PathBuf::from(value));
+        } else if part == "--planner" {
+            planner = Some(parse_planner_choice(parts.next()?)?);
+        } else if let Some(value) = part.strip_prefix("--planner=") {
+            if value.is_empty() {
+                return None;
+            }
+            planner = Some(parse_planner_choice(value)?);
+        } else if part.starts_with("--") {
+            return None;
+        } else {
+            intent_parts.push(part);
+        }
+    }
+    let intent = intent_parts.join(" ");
+    if intent.trim().is_empty() {
+        return None;
+    }
+    Some(PlanInvocation::Route {
+        intent,
+        export_path,
+        planner,
+    })
+}
+
+fn parse_planner_choice(value: &str) -> Option<PlannerChoice> {
+    let normalized = value.trim().to_ascii_lowercase();
+    match normalized.as_str() {
+        "configured" | "default" | "planner" => Some(PlannerChoice::Configured),
+        "selector" => Some(PlannerChoice::Selector),
+        "active" | "current" => Some(PlannerChoice::Active),
+        "low" | "medium" | "med" | "high" => {
+            TaskComplexity::parse(&normalized).map(PlannerChoice::Tier)
+        }
+        _ => ModelRef::parse_spec(value).map(PlannerChoice::Explicit),
+    }
+}
+
+fn parse_plan_execute_args(rest: &str) -> Option<PlanExecuteArgs> {
+    let mut yolo = false;
+    let mut max_tasks = None;
+    let mut parts = rest.split_whitespace();
+    while let Some(part) = parts.next() {
+        match part {
+            "--yolo" => yolo = true,
+            "--max" => {
+                max_tasks = Some(parts.next()?.parse().ok()?);
+            }
+            _ if part.starts_with("--max=") => {
+                max_tasks = Some(part.trim_start_matches("--max=").parse().ok()?);
+            }
+            "" => {}
+            _ => return None,
+        }
+    }
+    Some(PlanExecuteArgs { yolo, max_tasks })
+}
+
+async fn cmd_plan(args: &str, state: &mut AppState) -> Result<()> {
     let Some(invocation) = parse_plan_args(args) else {
         println!(
-            "  {DIM}Usage: /plan <intent>  ·  /plan <intent> --export <path>  ·  /plan show  ·  /plan validate{RESET}"
+            "  {DIM}Usage: /plan <intent> · /plan route [--planner high|selector|backend:model] <intent> · /plan status · /plan execute [--yolo] [--max N] · /plan show · /plan validate{RESET}"
         );
         return Ok(());
     };
 
     let default_path = default_spec_path(&state.config.workspace_root);
+    let routed_path = default_routed_plan_path(&state.config.workspace_root);
 
     let (intent, export_path) = match invocation {
         PlanInvocation::Show => {
@@ -657,6 +778,20 @@ async fn cmd_plan(args: &str, state: &AppState) -> Result<()> {
             return Ok(());
         }
         PlanInvocation::Validate => return cmd_plan_validate(state, &default_path).await,
+        PlanInvocation::Status => {
+            print_routed_plan_status(&routed_path)?;
+            return Ok(());
+        }
+        PlanInvocation::Route {
+            intent,
+            export_path,
+            planner,
+        } => {
+            return cmd_plan_route(state, &intent, export_path, planner, &routed_path).await;
+        }
+        PlanInvocation::Execute(args) => {
+            return cmd_plan_execute(state, &routed_path, args).await;
+        }
         PlanInvocation::Draft {
             intent,
             export_path,
@@ -720,6 +855,440 @@ async fn cmd_plan(args: &str, state: &AppState) -> Result<()> {
     );
 
     Ok(())
+}
+
+async fn cmd_plan_route(
+    state: &AppState,
+    intent: &str,
+    export_path: Option<PathBuf>,
+    planner_choice: Option<PlannerChoice>,
+    default_path: &Path,
+) -> Result<()> {
+    let planner = match resolve_planner_model(state, planner_choice) {
+        Ok(planner) => planner,
+        Err(e) => {
+            println!("  {RED}✗{RESET} {DIM}{e}{RESET}");
+            return Ok(());
+        }
+    };
+    let backend_desc = state.config.backend_descriptor_for(planner.backend);
+    if let Err(e) = validate(&backend_desc) {
+        println!("  {RED}✗{RESET} {DIM}planner backend is not ready: {e}{RESET}");
+        return Ok(());
+    }
+
+    println!(
+        "  {DIM}routing plan with{RESET} {}",
+        planner.detail_with_effort(planner.effort)
+    );
+    let messages = vec![
+        ChatMessage::System {
+            content: routed_planner_system_prompt(),
+        },
+        ChatMessage::User {
+            content: render_routed_planner_prompt(
+                intent,
+                &state.config.model_system,
+                Some(&planner),
+            )
+            .into(),
+        },
+    ];
+    let req = ChatRequest {
+        model: &planner.model,
+        messages: &messages,
+        tools: None,
+        stream: true,
+        stream_options: Some(StreamOptions {
+            include_usage: true,
+        }),
+        max_tokens: Some(2400),
+        effort: planner.effort,
+    };
+    let mut draft = String::new();
+    let mut reported_cost = None;
+    let result = stream_chat(&state.http, &backend_desc, &req, None, |chunk| {
+        if let Some(choice) = chunk.choices.first() {
+            if let Some(content) = &choice.delta.content {
+                draft.push_str(content);
+            }
+        }
+        if let Some(usage) = &chunk.usage {
+            if let Some(cost) = usage.cost {
+                reported_cost = Some(cost);
+            }
+        }
+    })
+    .await;
+
+    if let Some(cost) = reported_cost {
+        println!(
+            "  {DIM}planner cost{RESET}     {}",
+            catalog::format_usd(cost)
+        );
+    }
+
+    let plan = match result {
+        Ok(_) if !draft.trim().is_empty() => parse_routed_plan(
+            &draft,
+            intent,
+            Some(planner.clone()),
+            &state.config.model_system,
+        ),
+        Ok(_) => Err(anyhow!("planner returned an empty routed plan")),
+        Err(e) => Err(anyhow!("planner request failed: {e}")),
+    };
+    let plan = match plan {
+        Ok(plan) => plan,
+        Err(e) => {
+            println!("  {RED}✗{RESET} {DIM}{e}{RESET}");
+            return Ok(());
+        }
+    };
+
+    print_routed_plan_summary(&plan);
+    let out_path = export_path.unwrap_or_else(|| default_path.to_path_buf());
+    save_routed_plan(&out_path, &plan)?;
+    println!(
+        "  {GREEN}✓{RESET} {DIM}routed plan saved →{RESET} {}",
+        out_path.display()
+    );
+    Ok(())
+}
+
+fn resolve_planner_model(state: &AppState, choice: Option<PlannerChoice>) -> Result<ModelRef> {
+    let stack = &state.config.model_system;
+    let active = || ModelRef {
+        backend: state.config.backend,
+        model: state.model.clone(),
+        effort: state.active_effort,
+        thinking_depth: None,
+        notes: Some("Current active model.".into()),
+    };
+    match choice.unwrap_or(PlannerChoice::Configured) {
+        PlannerChoice::Configured => Ok(stack
+            .planner
+            .clone()
+            .or_else(|| stack.selector.clone())
+            .or_else(|| stack.orchestrator(TaskComplexity::High).cloned())
+            .or_else(|| stack.orchestrator(TaskComplexity::Medium).cloned())
+            .or_else(|| stack.orchestrator(TaskComplexity::Low).cloned())
+            .unwrap_or_else(active)),
+        PlannerChoice::Selector => stack
+            .selector
+            .clone()
+            .ok_or_else(|| anyhow!("modelSystem.selector is not configured")),
+        PlannerChoice::Tier(complexity) => stack
+            .orchestrator(complexity)
+            .or_else(|| stack.coder(complexity))
+            .cloned()
+            .ok_or_else(|| {
+                anyhow!(
+                    "no planner/orchestrator/coder is configured for {}",
+                    complexity.as_str()
+                )
+            }),
+        PlannerChoice::Active => Ok(active()),
+        PlannerChoice::Explicit(model) => Ok(model),
+    }
+}
+
+fn print_routed_plan_status(path: &Path) -> Result<()> {
+    let plan = match load_routed_plan(path) {
+        Ok(plan) => plan,
+        Err(_) if !path.exists() => {
+            println!(
+                "  {DIM}No routed plan yet at {} — run /plan route <intent>.{RESET}",
+                path.display()
+            );
+            return Ok(());
+        }
+        Err(e) => {
+            println!("  {RED}✗{RESET} {DIM}{e}{RESET}");
+            return Ok(());
+        }
+    };
+    print_routed_plan_summary(&plan);
+    println!("  {DIM}plan path{RESET}        {}", path.display());
+    Ok(())
+}
+
+fn print_routed_plan_summary(plan: &RoutedPlan) {
+    let pending = plan
+        .tasks
+        .iter()
+        .filter(|task| task.status == PlanTaskStatus::Pending)
+        .count();
+    let running = plan
+        .tasks
+        .iter()
+        .filter(|task| task.status == PlanTaskStatus::Running)
+        .count();
+    let done = plan
+        .tasks
+        .iter()
+        .filter(|task| task.status == PlanTaskStatus::Done)
+        .count();
+    let failed = plan
+        .tasks
+        .iter()
+        .filter(|task| task.status == PlanTaskStatus::Failed)
+        .count();
+    println!("  {DIM}routed plan{RESET}      {}", plan.goal);
+    println!(
+        "  {DIM}tasks{RESET}            {} total · {} done · {} running · {} pending · {} failed",
+        plan.tasks.len(),
+        done,
+        running,
+        pending,
+        failed
+    );
+    for task in &plan.tasks {
+        println!(
+            "  {DIM}- {:<10}{RESET} {:<7} {:<7} {}{}",
+            task.id,
+            task.status.as_str(),
+            task.complexity.as_str(),
+            task.title,
+            format_task_model_suffix(task)
+        );
+    }
+}
+
+fn format_task_model_suffix(task: &RoutedPlanTask) -> String {
+    match &task.assigned_model {
+        Some(model) => {
+            let effort = task.effort.or(model.effort);
+            format!(" {DIM}→{RESET} {}", model.detail_with_effort(effort))
+        }
+        None => " {DIM}→ no configured coder{RESET}".into(),
+    }
+}
+
+async fn cmd_plan_execute(state: &mut AppState, path: &Path, args: PlanExecuteArgs) -> Result<()> {
+    let mut plan = match load_routed_plan(path) {
+        Ok(plan) => plan,
+        Err(_) if !path.exists() => {
+            println!(
+                "  {DIM}No routed plan yet at {} — run /plan route <intent>.{RESET}",
+                path.display()
+            );
+            return Ok(());
+        }
+        Err(e) => {
+            println!("  {RED}✗{RESET} {DIM}{e}{RESET}");
+            return Ok(());
+        }
+    };
+    let original = ActiveModelSnapshot::capture(state);
+    let mut ran = 0usize;
+    let mut stopped_on_error = false;
+
+    while args.max_tasks.map(|max| ran < max).unwrap_or(true) {
+        let Some(index) = next_ready_task_index(&plan) else {
+            break;
+        };
+        let task = plan.tasks[index].clone();
+        let Some(model) = task
+            .assigned_model
+            .clone()
+            .or_else(|| state.config.model_system.coder(task.complexity).cloned())
+        else {
+            plan.tasks[index].status = PlanTaskStatus::Failed;
+            plan.tasks[index].last_error = Some(format!(
+                "modelSystem.coders.{} is not configured",
+                task.complexity.as_str()
+            ));
+            save_routed_plan(path, &plan)?;
+            stopped_on_error = true;
+            break;
+        };
+
+        plan.tasks[index].status = PlanTaskStatus::Running;
+        plan.tasks[index].assigned_model = Some(model.clone());
+        plan.tasks[index].last_error = None;
+        save_routed_plan(path, &plan)?;
+
+        println!(
+            "  {DIM}plan task{RESET}        {} · {} · {}",
+            task.id,
+            task.complexity.as_str(),
+            model.detail_with_effort(task.effort.or(model.effort))
+        );
+        if let Err(e) = route::apply_model_ref(state, &model, task.effort) {
+            plan.tasks[index].status = PlanTaskStatus::Failed;
+            plan.tasks[index].last_error = Some(format!("could not apply routed model: {e}"));
+            save_routed_plan(path, &plan)?;
+            stopped_on_error = true;
+            break;
+        }
+
+        let prompt = render_routed_task_prompt(&plan, &task);
+        match run_user_turn(
+            state,
+            TurnOptions {
+                user_prompt: prompt,
+                auto_verify_tests: false,
+                yolo_approve: args.yolo,
+                source: "plan-execute",
+            },
+        )
+        .await
+        {
+            Ok(outcome) => {
+                plan.tasks[index].status = PlanTaskStatus::Done;
+                plan.tasks[index].result = last_assistant_text(&outcome.run_result.messages)
+                    .map(|s| truncate_summary(&s, 2000));
+                plan.tasks[index].last_error = None;
+                save_routed_plan(path, &plan)?;
+                ran += 1;
+            }
+            Err(e) => {
+                plan.tasks[index].status = PlanTaskStatus::Failed;
+                plan.tasks[index].last_error = Some(e.to_string());
+                save_routed_plan(path, &plan)?;
+                stopped_on_error = true;
+                break;
+            }
+        }
+    }
+
+    if let Err(e) = original.restore(state) {
+        println!("  {YELLOW}!{RESET} {DIM}could not restore original active model: {e}{RESET}");
+    }
+
+    if ran == 0 && !stopped_on_error {
+        if plan
+            .tasks
+            .iter()
+            .all(|task| task.status == PlanTaskStatus::Done)
+        {
+            println!("  {GREEN}✓{RESET} {DIM}routed plan already complete{RESET}");
+        } else {
+            println!(
+                "  {DIM}No ready tasks. Check failed or unmet dependencies with /plan status.{RESET}"
+            );
+        }
+    } else if stopped_on_error {
+        println!(
+            "  {RED}✗{RESET} {DIM}routed execution stopped after {} completed task(s); inspect /plan status.{RESET}",
+            ran
+        );
+    } else {
+        println!(
+            "  {GREEN}✓{RESET} {DIM}routed execution ran {} task(s); status saved →{RESET} {}",
+            ran,
+            path.display()
+        );
+    }
+    print_routed_plan_summary(&plan);
+    Ok(())
+}
+
+#[derive(Debug, Clone)]
+struct ActiveModelSnapshot {
+    backend: BackendName,
+    model_override: Option<String>,
+    backend_desc: BackendDescriptor,
+    model: String,
+    active_effort: Option<EffortLevel>,
+    warmed_fingerprint: Option<u64>,
+}
+
+impl ActiveModelSnapshot {
+    fn capture(state: &AppState) -> Self {
+        Self {
+            backend: state.config.backend,
+            model_override: state.config.model_override.clone(),
+            backend_desc: state.backend.clone(),
+            model: state.model.clone(),
+            active_effort: state.active_effort,
+            warmed_fingerprint: state.warmed_fingerprint,
+        }
+    }
+
+    fn restore(self, state: &mut AppState) -> Result<()> {
+        state.config.backend = self.backend;
+        state.config.model_override = self.model_override;
+        state.backend = self.backend_desc;
+        state.model = self.model;
+        state.active_effort = self.active_effort;
+        state.warmed_fingerprint = self.warmed_fingerprint;
+        state.rebuild_client()
+    }
+}
+
+fn next_ready_task_index(plan: &RoutedPlan) -> Option<usize> {
+    plan.tasks.iter().position(|task| {
+        matches!(
+            task.status,
+            PlanTaskStatus::Pending | PlanTaskStatus::Running
+        ) && task.depends_on.iter().all(|dep| {
+            plan.tasks
+                .iter()
+                .any(|candidate| candidate.id == *dep && candidate.status == PlanTaskStatus::Done)
+        })
+    })
+}
+
+fn render_routed_task_prompt(plan: &RoutedPlan, task: &RoutedPlanTask) -> String {
+    let mut out = String::new();
+    out.push_str("Execute one task from a Small Harness routed plan.\n\n");
+    out.push_str("Overall goal:\n");
+    out.push_str(&plan.goal);
+    out.push_str("\n\nTask:\n");
+    out.push_str(&format!("- id: {}\n", task.id));
+    out.push_str(&format!("- title: {}\n", task.title));
+    out.push_str(&format!("- role: {}\n", task.role));
+    out.push_str(&format!("- complexity: {}\n", task.complexity.as_str()));
+    if !task.depends_on.is_empty() {
+        out.push_str("- completed dependencies:\n");
+        for dep in &task.depends_on {
+            if let Some(prev) = plan.tasks.iter().find(|candidate| candidate.id == *dep) {
+                out.push_str(&format!("  - {}: {}\n", prev.id, prev.title));
+                if let Some(result) = prev.result.as_deref().filter(|s| !s.trim().is_empty()) {
+                    out.push_str("    result: ");
+                    out.push_str(&truncate_summary(result, 400));
+                    out.push('\n');
+                }
+            }
+        }
+    }
+    out.push_str("\nInstructions:\n");
+    out.push_str(&task.prompt);
+    out.push_str("\n\nAcceptance criteria:\n");
+    if task.acceptance.is_empty() {
+        out.push_str("- Complete the task without expanding into unrelated plan tasks.\n");
+    } else {
+        for item in &task.acceptance {
+            out.push_str("- ");
+            out.push_str(item);
+            out.push('\n');
+        }
+    }
+    out.push_str("\nWork only on this task. Do not perform later tasks unless they are strictly required to make this task coherent. When finished, summarize what changed and any verification you ran.");
+    out
+}
+
+fn last_assistant_text(messages: &[ChatMessage]) -> Option<String> {
+    messages.iter().rev().find_map(|message| match message {
+        ChatMessage::Assistant {
+            content: Some(content),
+            ..
+        } if !content.trim().is_empty() => Some(content.trim().to_string()),
+        _ => None,
+    })
+}
+
+fn truncate_summary(text: &str, max_chars: usize) -> String {
+    let mut out = String::new();
+    for ch in text.trim().chars().take(max_chars) {
+        out.push(ch);
+    }
+    if text.trim().chars().count() > max_chars {
+        out.push_str("...");
+    }
+    out
 }
 
 /// `/plan validate`: read the saved spec's Done Criteria and check each one
@@ -1054,6 +1623,24 @@ mod tests {
             parse_plan_args("validate the csv export"),
             Some(PlanInvocation::Draft { .. })
         ));
+        assert!(matches!(
+            parse_plan_args("status"),
+            Some(PlanInvocation::Status)
+        ));
+        assert!(matches!(
+            parse_plan_args("route --planner high build oauth"),
+            Some(PlanInvocation::Route {
+                planner: Some(PlannerChoice::Tier(TaskComplexity::High)),
+                ..
+            })
+        ));
+        assert!(matches!(
+            parse_plan_args("execute --yolo --max 2"),
+            Some(PlanInvocation::Execute(PlanExecuteArgs {
+                yolo: true,
+                max_tasks: Some(2)
+            }))
+        ));
 
         let Some(PlanInvocation::Draft {
             intent,
@@ -1114,7 +1701,9 @@ mod tests {
             openrouter: crate::backends::OpenRouterConfig::default(),
         };
 
-        cmd_plan("add a CSV export command", &state).await.unwrap();
+        cmd_plan("add a CSV export command", &mut state)
+            .await
+            .unwrap();
 
         let body = fs::read_to_string(dir.path().join(".small-harness/spec.md")).unwrap();
         for section in [
@@ -1146,7 +1735,7 @@ mod tests {
 
         cmd_plan(
             &format!("build a dashboard --export {}", out_path.display()),
-            &state,
+            &mut state,
         )
         .await
         .unwrap();
@@ -1161,8 +1750,8 @@ mod tests {
     #[tokio::test]
     async fn plan_show_without_spec_is_noop() {
         let dir = tempfile::tempdir().unwrap();
-        let state = test_state(dir.path());
-        cmd_plan("show", &state).await.unwrap();
+        let mut state = test_state(dir.path());
+        cmd_plan("show", &mut state).await.unwrap();
         assert!(!dir.path().join(".small-harness/spec.md").exists());
     }
 }

--- a/src/commands/route.rs
+++ b/src/commands/route.rs
@@ -169,6 +169,7 @@ fn print_route_status(stack: &ModelSystemConfig) {
         );
         return;
     }
+    print_model_ref("planner", stack.planner.as_ref());
     print_model_ref("selector", stack.selector.as_ref());
     print_tier_set("orchestrator", &stack.orchestrators);
     print_tier_set("coder", &stack.coders);
@@ -200,6 +201,13 @@ fn print_route_template() {
 {{
   "modelSystem": {{
     "enabled": true,
+    "planner": {{
+      "backend": "openrouter",
+      "model": "anthropic/claude-opus-4.8",
+      "effort": "high",
+      "thinkingDepth": "deep",
+      "notes": "Breaks a goal into a routed execution plan."
+    }},
     "selector": {{
       "backend": "openrouter",
       "model": "openrouter/fusion",
@@ -438,6 +446,7 @@ fn render_selector_prompt(stack: &ModelSystemConfig, task: &str) -> String {
     out.push_str("Route this task using only the configured model system.\n\nTask:\n");
     out.push_str(task.trim());
     out.push_str("\n\nConfigured routes:\n");
+    append_model_line(&mut out, "planner", stack.planner.as_ref());
     append_model_line(&mut out, "selector", stack.selector.as_ref());
     append_model_line(
         &mut out,
@@ -620,7 +629,7 @@ fn format_active_effort_suffix(effort: Option<EffortLevel>) -> String {
         .unwrap_or_default()
 }
 
-fn apply_model_ref(
+pub(super) fn apply_model_ref(
     state: &mut AppState,
     model: &ModelRef,
     effort_override: Option<EffortLevel>,

--- a/src/commands/session.rs
+++ b/src/commands/session.rs
@@ -153,12 +153,7 @@ pub(super) async fn cmd_path(args: &str, state: &mut AppState) -> Result<()> {
             if diff.is_empty() {
                 println!("  {DIM}No file differences vs path `{rest}`.{RESET}");
             } else {
-                for line in diff.lines().take(120) {
-                    println!("  {DIM}{line}{RESET}");
-                }
-                if diff.lines().count() > 120 {
-                    println!("  {DIM}…diff truncated for display{RESET}");
-                }
+                crate::diff_view::print_diff(&diff, 120);
             }
         }
         "pick" => {
@@ -191,12 +186,7 @@ pub(super) async fn cmd_path(args: &str, state: &mut AppState) -> Result<()> {
             let diff = state.path_store.diff_with(name, &state.workspace_root())?;
             if !diff.is_empty() {
                 println!();
-                for line in diff.lines().take(80) {
-                    println!("  {DIM}{line}{RESET}");
-                }
-                if diff.lines().count() > 80 {
-                    println!("  {DIM}…diff truncated for display{RESET}");
-                }
+                crate::diff_view::print_diff(&diff, 80);
                 println!();
             }
             println!(

--- a/src/config.rs
+++ b/src/config.rs
@@ -259,6 +259,55 @@ impl Default for ScorecardConfig {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FableUsageConfig {
+    #[serde(default = "default_true")]
+    pub enabled: bool,
+    #[serde(rename = "weeklyTokenBudget", default)]
+    pub weekly_token_budget: Option<u64>,
+    #[serde(rename = "capShare", default = "default_fable_cap_share")]
+    pub cap_share: f64,
+    #[serde(rename = "weekStartsOn", default = "default_fable_week_starts_on")]
+    pub week_starts_on: String,
+    #[serde(rename = "fableModelMatches", default = "default_fable_model_matches")]
+    pub fable_model_matches: Vec<String>,
+    #[serde(
+        rename = "claudeModelMatches",
+        default = "default_claude_model_matches"
+    )]
+    pub claude_model_matches: Vec<String>,
+}
+
+fn default_fable_cap_share() -> f64 {
+    0.5
+}
+
+fn default_fable_week_starts_on() -> String {
+    "monday".into()
+}
+
+fn default_fable_model_matches() -> Vec<String> {
+    vec!["fable".into()]
+}
+
+fn default_claude_model_matches() -> Vec<String> {
+    vec!["anthropic/".into(), "claude".into(), "fable".into()]
+}
+
+impl Default for FableUsageConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            weekly_token_budget: None,
+            cap_share: default_fable_cap_share(),
+            week_starts_on: default_fable_week_starts_on(),
+            fable_model_matches: default_fable_model_matches(),
+            claude_model_matches: default_claude_model_matches(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CheckpointConfig {
     #[serde(default = "default_true")]
     pub enabled: bool,
@@ -595,6 +644,7 @@ pub struct AgentConfig {
     pub tool_selection: ToolSelection,
     pub display: DisplayConfig,
     pub scorecard: ScorecardConfig,
+    pub fable: FableUsageConfig,
     pub slash_commands: bool,
     pub context: ContextConfig,
     pub history: HistoryConfig,
@@ -676,6 +726,7 @@ impl Default for AgentConfig {
             tool_selection: ToolSelection::Auto,
             display: DisplayConfig::default(),
             scorecard: ScorecardConfig::default(),
+            fable: FableUsageConfig::default(),
             slash_commands: true,
             context: ContextConfig::default(),
             history: HistoryConfig::default(),
@@ -717,6 +768,7 @@ struct FileConfig {
     tool_selection: Option<String>,
     display: Option<DisplayConfig>,
     scorecard: Option<ScorecardConfig>,
+    fable: Option<FableUsageConfig>,
     #[serde(rename = "slashCommands")]
     slash_commands: Option<bool>,
     context: Option<ContextConfig>,
@@ -1109,6 +1161,9 @@ pub fn load_config() -> AgentConfig {
                     if let Some(s) = file.scorecard {
                         config.scorecard = s;
                     }
+                    if let Some(f) = file.fable {
+                        config.fable = f;
+                    }
                     if let Some(sc) = file.slash_commands {
                         config.slash_commands = sc;
                     }
@@ -1354,6 +1409,37 @@ mod tests {
         assert_eq!(
             stack.security_reviewer.as_ref().map(|m| m.model.as_str()),
             Some("openrouter/fusion")
+        );
+    }
+
+    #[test]
+    fn parses_fable_usage_config() {
+        let file: FileConfig = serde_json::from_str(
+            r#"{
+              "fable": {
+                "enabled": true,
+                "weeklyTokenBudget": 200000,
+                "capShare": 0.5,
+                "weekStartsOn": "sunday",
+                "fableModelMatches": ["claude-fable", "fable"],
+                "claudeModelMatches": ["anthropic/", "claude"]
+              }
+            }"#,
+        )
+        .unwrap();
+        let fable = file.fable.unwrap();
+
+        assert!(fable.enabled);
+        assert_eq!(fable.weekly_token_budget, Some(200_000));
+        assert_eq!(fable.cap_share, 0.5);
+        assert_eq!(fable.week_starts_on, "sunday");
+        assert_eq!(
+            fable.fable_model_matches,
+            vec!["claude-fable".to_string(), "fable".to_string()]
+        );
+        assert_eq!(
+            fable.claude_model_matches,
+            vec!["anthropic/".to_string(), "claude".to_string()]
         );
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -140,6 +140,14 @@ impl OperatorMode {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
+pub enum ColorMode {
+    Auto,
+    Always,
+    Never,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
 pub enum OutsideWorkspace {
     Prompt,
     Deny,
@@ -180,6 +188,10 @@ pub struct DisplayConfig {
     pub show_banner: bool,
     #[serde(rename = "eventLog", default)]
     pub event_log: crate::turn_trace::EventLogConfig,
+    #[serde(default = "default_color_mode")]
+    pub color: ColorMode,
+    #[serde(default)]
+    pub ascii: bool,
 }
 
 fn default_true() -> bool {
@@ -197,6 +209,9 @@ fn default_loader_text() -> String {
 fn default_loader_style() -> LoaderStyle {
     LoaderStyle::Spinner
 }
+fn default_color_mode() -> ColorMode {
+    ColorMode::Auto
+}
 
 impl Default for DisplayConfig {
     fn default() -> Self {
@@ -208,6 +223,8 @@ impl Default for DisplayConfig {
             reasoning: false,
             show_banner: true,
             event_log: crate::turn_trace::EventLogConfig::default(),
+            color: default_color_mode(),
+            ascii: false,
         }
     }
 }

--- a/src/diff_view.rs
+++ b/src/diff_view.rs
@@ -1,0 +1,104 @@
+//! Colored rendering for unified diffs produced by [`crate::tools::diff::unified_diff`].
+//!
+//! Classification is order-sensitive: file headers (`---`/`+++`) must be
+//! checked before the single-character `-`/`+` line markers, since a header
+//! line also starts with those characters.
+
+use crate::theme::{ACCENT, ERROR, MUTED, RESET, SUCCESS};
+
+/// Apply theme colors to a single diff line based on its unified-diff prefix.
+/// Pure and side-effect-free so classification is directly unit-testable.
+pub fn colorize_diff_line(line: &str) -> String {
+    if line.starts_with("+++") || line.starts_with("---") {
+        format!("{MUTED}{line}{RESET}")
+    } else if line.starts_with("@@") {
+        format!("{ACCENT}{line}{RESET}")
+    } else if let Some(rest) = line.strip_prefix('+') {
+        format!("{SUCCESS}+{rest}{RESET}")
+    } else if let Some(rest) = line.strip_prefix('-') {
+        format!("{ERROR}-{rest}{RESET}")
+    } else {
+        format!("{MUTED}{line}{RESET}")
+    }
+}
+
+/// Build the colored, gutter-indented, capped diff text (pure — testable
+/// without capturing stdout).
+fn render_diff(diff: &str, max_lines: usize) -> String {
+    let mut out = String::new();
+    for line in diff.lines().take(max_lines) {
+        out.push_str("  ");
+        out.push_str(&colorize_diff_line(line));
+        out.push('\n');
+    }
+    if diff.lines().count() > max_lines {
+        out.push_str(&format!("  {MUTED}…diff truncated for display{RESET}\n"));
+    }
+    out
+}
+
+/// Print a unified diff with per-line coloring, indented by the caller's
+/// gutter, capped at `max_lines` with a truncation notice.
+pub fn print_diff(diff: &str, max_lines: usize) {
+    print!("{}", render_diff(diff, max_lines));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn classifies_added_line() {
+        let out = colorize_diff_line("+hello");
+        assert!(out.contains('+'));
+        assert!(out.contains("hello"));
+        assert!(out.starts_with(&SUCCESS.to_string()));
+    }
+
+    #[test]
+    fn classifies_removed_line() {
+        let out = colorize_diff_line("-hello");
+        assert!(out.starts_with(&ERROR.to_string()));
+    }
+
+    #[test]
+    fn classifies_hunk_header() {
+        let out = colorize_diff_line("@@ -1 +1 @@");
+        assert!(out.starts_with(&ACCENT.to_string()));
+    }
+
+    #[test]
+    fn file_headers_are_not_treated_as_added_or_removed() {
+        let plus_header = colorize_diff_line("+++ path.rs");
+        let minus_header = colorize_diff_line("--- path.rs");
+        assert!(plus_header.starts_with(&MUTED.to_string()));
+        assert!(minus_header.starts_with(&MUTED.to_string()));
+        assert!(!plus_header.starts_with(&SUCCESS.to_string()));
+        assert!(!minus_header.starts_with(&ERROR.to_string()));
+    }
+
+    #[test]
+    fn plain_context_line_is_muted() {
+        let out = colorize_diff_line("unchanged context");
+        assert!(out.starts_with(&MUTED.to_string()));
+    }
+
+    #[test]
+    fn truncation_notice_appears_past_cap() {
+        let diff = (0..5)
+            .map(|i| format!("+line{i}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let rendered = render_diff(&diff, 3);
+        assert_eq!(rendered.lines().count(), 4); // 3 diff lines + notice
+        assert!(rendered.contains("truncated for display"));
+        assert!(!rendered.contains("line3")); // beyond the cap
+    }
+
+    #[test]
+    fn no_truncation_notice_when_under_cap() {
+        let diff = "+only line";
+        let rendered = render_diff(diff, 80);
+        assert!(!rendered.contains("truncated"));
+    }
+}

--- a/src/fable_usage.rs
+++ b/src/fable_usage.rs
@@ -1,0 +1,537 @@
+use anyhow::Result;
+use chrono::{DateTime, Datelike, Duration, NaiveDate, Utc, Weekday};
+use std::path::PathBuf;
+
+use crate::config::FableUsageConfig;
+use crate::scorecard::{ScorecardStoreDiagnostics, ScorecardTurn};
+
+const RESET: crate::theme::Style = crate::theme::RESET;
+const DIM: crate::theme::Style = crate::theme::MUTED;
+const GREEN: crate::theme::Style = crate::theme::SUCCESS;
+const YELLOW: crate::theme::Style = crate::theme::WARN;
+const RED: crate::theme::Style = crate::theme::ERROR;
+const CYAN: crate::theme::Style = crate::theme::ACCENT_DEEP;
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct UsageBucket {
+    pub input_tokens: u64,
+    pub output_tokens: u64,
+    pub total_tokens: u64,
+    pub turns: usize,
+}
+
+impl UsageBucket {
+    fn add_turn(&mut self, turn: &ScorecardTurn) {
+        self.input_tokens += turn.input_tokens;
+        self.output_tokens += turn.output_tokens;
+        self.total_tokens += turn.total_tokens;
+        self.turns += 1;
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FableTurnMarker {
+    pub timestamp: DateTime<Utc>,
+    pub backend: String,
+    pub model: String,
+    pub session_id: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct FableUsageReport {
+    pub path: Option<PathBuf>,
+    pub diagnostics: Option<ScorecardStoreDiagnostics>,
+    pub window_start: DateTime<Utc>,
+    pub window_end: DateTime<Utc>,
+    pub cap_share: f64,
+    pub weekly_token_budget: Option<u64>,
+    pub fable_cap_tokens: Option<u64>,
+    pub fable: UsageBucket,
+    pub claude: UsageBucket,
+    pub other_claude: UsageBucket,
+    pub all_tracked: UsageBucket,
+    pub last_fable: Option<FableTurnMarker>,
+}
+
+pub fn load_report(config: &FableUsageConfig) -> Result<FableUsageReport> {
+    let read = crate::scorecard::load_turn_records()?;
+    Ok(build_report(
+        read.path,
+        read.diagnostics,
+        &read.turns,
+        config,
+        Utc::now(),
+    ))
+}
+
+pub fn is_fable_model(config: &FableUsageConfig, model: &str) -> bool {
+    model_matches(model, &config.fable_model_matches, &["fable"])
+}
+
+pub fn format_footer_suffix(config: &FableUsageConfig, current_model: &str) -> Result<String> {
+    if !config.enabled || !is_fable_model(config, current_model) {
+        return Ok(String::new());
+    }
+    let report = load_report(config)?;
+    Ok(format_footer_suffix_for_report(&report))
+}
+
+pub fn render_report(report: &FableUsageReport, scorecard_enabled: bool) -> String {
+    let mut out = String::new();
+    out.push_str(&format!(
+        "  {DIM}fable tracker{RESET}   Claude Fable weekly usage\n"
+    ));
+    match &report.path {
+        Some(path) => out.push_str(&format!(
+            "  {DIM}store{RESET}           {}\n",
+            path.display()
+        )),
+        None => out.push_str(&format!("  {DIM}store{RESET}           unavailable\n")),
+    }
+    if let Some(diagnostics) = report.diagnostics.as_ref() {
+        if diagnostics.malformed_count > 0 {
+            out.push_str(&format!(
+                "  {YELLOW}!{RESET} {DIM}store warning{RESET}  skipped {} malformed line(s); run /scorecard doctor\n",
+                diagnostics.malformed_count
+            ));
+        }
+    }
+    out.push_str(&format!(
+        "  {DIM}window{RESET}          {} -> {}\n",
+        format_ts(report.window_start),
+        format_ts(report.window_end)
+    ));
+    out.push('\n');
+    out.push_str(&format!(
+        "  {CYAN}{:<14}{RESET} {:>10}   {CYAN}{:<14}{RESET} {:>10}   {CYAN}{:<14}{RESET} {:>10}\n",
+        "Fable tokens",
+        format_tokens(report.fable.total_tokens),
+        "Fable turns",
+        report.fable.turns,
+        "Cap share",
+        format_percent(report.cap_share)
+    ));
+    out.push_str(&format!(
+        "  {CYAN}{:<14}{RESET} {:>10}   {CYAN}{:<14}{RESET} {:>10}   {CYAN}{:<14}{RESET} {:>10}\n",
+        "Fable in",
+        format_tokens(report.fable.input_tokens),
+        "Fable out",
+        format_tokens(report.fable.output_tokens),
+        "All tracked",
+        format_tokens(report.all_tracked.total_tokens)
+    ));
+    out.push_str(&format!(
+        "  {CYAN}{:<14}{RESET} {:>10}   {CYAN}{:<14}{RESET} {:>10}   {CYAN}{:<14}{RESET} {:>10}\n",
+        "Claude total",
+        format_tokens(report.claude.total_tokens),
+        "Other Claude",
+        format_tokens(report.other_claude.total_tokens),
+        "Claude share",
+        report
+            .fable_share_of_claude()
+            .map(format_percent)
+            .unwrap_or_else(|| "n/a".to_string())
+    ));
+    out.push('\n');
+
+    match report.fable_cap_tokens {
+        Some(cap) => {
+            let ratio = usage_ratio(report.fable.total_tokens, cap);
+            let (color, label) = cap_status(ratio);
+            out.push_str(&format!(
+                "  {DIM}cap{RESET}             {color}{} / {} ({}) · {} left · {label}{RESET}\n",
+                format_tokens(report.fable.total_tokens),
+                format_tokens(cap),
+                format_percent(ratio),
+                format_tokens(cap.saturating_sub(report.fable.total_tokens))
+            ));
+            if report.fable.total_tokens > cap {
+                out.push_str(&format!(
+                    "  {RED}!{RESET} {DIM}Fable is over the configured weekly allowance.{RESET}\n"
+                ));
+            }
+        }
+        None => out.push_str(&format!(
+            "  {DIM}cap{RESET}             not configured · set fable.weeklyTokenBudget to show remaining allowance\n"
+        )),
+    }
+
+    if let Some(share) = report.fable_share_of_claude() {
+        let (color, label) = share_status(share, report.cap_share);
+        out.push_str(&format!(
+            "  {DIM}tracked share{RESET}   {color}{} of tracked Claude usage · {label}{RESET}\n",
+            format_percent(share)
+        ));
+    } else {
+        out.push_str(&format!(
+            "  {DIM}tracked share{RESET}   n/a · no Claude-family turns in this window\n"
+        ));
+    }
+
+    match &report.last_fable {
+        Some(last) => out.push_str(&format!(
+            "  {DIM}last Fable{RESET}      {} · {} · {} · {}\n",
+            format_ts(last.timestamp),
+            last.backend,
+            one_line(&last.model, 48),
+            last.session_id
+        )),
+        None => out.push_str(&format!(
+            "  {DIM}last Fable{RESET}      none in this window\n"
+        )),
+    }
+
+    if report.fable.turns == 0 {
+        out.push_str(&format!(
+            "  {DIM}hint{RESET}            switch to a model id containing `fable` to start tracking Fable turns\n"
+        ));
+    }
+    if !scorecard_enabled {
+        out.push_str(&format!(
+            "  {YELLOW}!{RESET} {DIM}scorecard.enabled is false, so new turns are not being recorded for this tracker.{RESET}\n"
+        ));
+    }
+    if report.weekly_token_budget.is_none() {
+        out.push_str(&format!(
+            "  {DIM}config{RESET}          example: {{ \"fable\": {{ \"weeklyTokenBudget\": 200000, \"capShare\": 0.5 }} }}\n"
+        ));
+    }
+    out.push_str(&format!(
+        "  {DIM}scope{RESET}           Small Harness tracked turns only; external Claude app usage is not visible here.\n"
+    ));
+    out
+}
+
+impl FableUsageReport {
+    pub fn fable_share_of_claude(&self) -> Option<f64> {
+        if self.claude.total_tokens == 0 {
+            None
+        } else {
+            Some(self.fable.total_tokens as f64 / self.claude.total_tokens as f64)
+        }
+    }
+}
+
+fn build_report(
+    path: Option<PathBuf>,
+    diagnostics: Option<ScorecardStoreDiagnostics>,
+    turns: &[ScorecardTurn],
+    config: &FableUsageConfig,
+    now: DateTime<Utc>,
+) -> FableUsageReport {
+    let cap_share = normalized_cap_share(config.cap_share);
+    let week_start = week_start(now, parse_weekday(&config.week_starts_on));
+    let week_end = week_start + Duration::days(7);
+    let fable_cap_tokens = config.weekly_token_budget.and_then(|budget| {
+        if budget == 0 {
+            None
+        } else {
+            Some(((budget as f64 * cap_share).round() as u64).max(1))
+        }
+    });
+
+    let mut fable = UsageBucket::default();
+    let mut claude = UsageBucket::default();
+    let mut all_tracked = UsageBucket::default();
+    let mut last_fable: Option<FableTurnMarker> = None;
+
+    for turn in turns {
+        let Some(timestamp) = parse_timestamp(&turn.timestamp) else {
+            continue;
+        };
+        if timestamp < week_start || timestamp >= week_end {
+            continue;
+        }
+        all_tracked.add_turn(turn);
+        let is_fable = is_fable_model(config, &turn.model);
+        let is_claude = is_fable || is_claude_model(config, &turn.model);
+        if is_claude {
+            claude.add_turn(turn);
+        }
+        if is_fable {
+            fable.add_turn(turn);
+            if last_fable
+                .as_ref()
+                .map(|last| timestamp > last.timestamp)
+                .unwrap_or(true)
+            {
+                last_fable = Some(FableTurnMarker {
+                    timestamp,
+                    backend: turn.backend.clone(),
+                    model: turn.model.clone(),
+                    session_id: turn.session_id.clone(),
+                });
+            }
+        }
+    }
+
+    let other_claude = UsageBucket {
+        input_tokens: claude.input_tokens.saturating_sub(fable.input_tokens),
+        output_tokens: claude.output_tokens.saturating_sub(fable.output_tokens),
+        total_tokens: claude.total_tokens.saturating_sub(fable.total_tokens),
+        turns: claude.turns.saturating_sub(fable.turns),
+    };
+
+    FableUsageReport {
+        path,
+        diagnostics,
+        window_start: week_start,
+        window_end: week_end,
+        cap_share,
+        weekly_token_budget: config.weekly_token_budget,
+        fable_cap_tokens,
+        fable,
+        claude,
+        other_claude,
+        all_tracked,
+        last_fable,
+    }
+}
+
+fn format_footer_suffix_for_report(report: &FableUsageReport) -> String {
+    if report.fable.total_tokens == 0 {
+        return String::new();
+    }
+    if let Some(cap) = report.fable_cap_tokens {
+        return format!(
+            "Fable {} / {} wk ({})",
+            format_tokens(report.fable.total_tokens),
+            format_tokens(cap),
+            format_percent(usage_ratio(report.fable.total_tokens, cap))
+        );
+    }
+    if let Some(share) = report.fable_share_of_claude() {
+        return format!(
+            "Fable {} wk · {} Claude",
+            format_tokens(report.fable.total_tokens),
+            format_percent(share)
+        );
+    }
+    format!("Fable {} wk", format_tokens(report.fable.total_tokens))
+}
+
+fn is_claude_model(config: &FableUsageConfig, model: &str) -> bool {
+    model_matches(
+        model,
+        &config.claude_model_matches,
+        &["anthropic/", "claude", "fable"],
+    )
+}
+
+fn model_matches(model: &str, configured: &[String], defaults: &[&str]) -> bool {
+    let model = model.to_ascii_lowercase();
+    let mut saw_configured = false;
+    for pattern in configured {
+        let pattern = pattern.trim().to_ascii_lowercase();
+        if pattern.is_empty() {
+            continue;
+        }
+        saw_configured = true;
+        if model.contains(&pattern) {
+            return true;
+        }
+    }
+    !saw_configured
+        && defaults
+            .iter()
+            .any(|pattern| model.contains(&pattern.to_ascii_lowercase()))
+}
+
+fn parse_weekday(value: &str) -> Weekday {
+    match value.trim().to_ascii_lowercase().as_str() {
+        "sun" | "sunday" => Weekday::Sun,
+        "tue" | "tues" | "tuesday" => Weekday::Tue,
+        "wed" | "wednesday" => Weekday::Wed,
+        "thu" | "thur" | "thurs" | "thursday" => Weekday::Thu,
+        "fri" | "friday" => Weekday::Fri,
+        "sat" | "saturday" => Weekday::Sat,
+        _ => Weekday::Mon,
+    }
+}
+
+fn week_start(now: DateTime<Utc>, starts_on: Weekday) -> DateTime<Utc> {
+    let today = now.date_naive();
+    let today_idx = today.weekday().num_days_from_monday() as i64;
+    let start_idx = starts_on.num_days_from_monday() as i64;
+    let days_since_start = (today_idx - start_idx).rem_euclid(7);
+    date_at_midnight(today - Duration::days(days_since_start))
+}
+
+fn date_at_midnight(date: NaiveDate) -> DateTime<Utc> {
+    DateTime::from_naive_utc_and_offset(date.and_hms_opt(0, 0, 0).unwrap(), Utc)
+}
+
+fn parse_timestamp(timestamp: &str) -> Option<DateTime<Utc>> {
+    DateTime::parse_from_rfc3339(timestamp)
+        .ok()
+        .map(|dt| dt.with_timezone(&Utc))
+}
+
+fn normalized_cap_share(value: f64) -> f64 {
+    if value.is_finite() {
+        value.clamp(0.01, 1.0)
+    } else {
+        0.5
+    }
+}
+
+fn usage_ratio(used: u64, cap: u64) -> f64 {
+    if cap == 0 {
+        0.0
+    } else {
+        used as f64 / cap as f64
+    }
+}
+
+fn cap_status(ratio: f64) -> (crate::theme::Style, &'static str) {
+    if ratio >= 1.0 {
+        (RED, "over cap")
+    } else if ratio >= 0.8 {
+        (YELLOW, "near cap")
+    } else {
+        (GREEN, "on track")
+    }
+}
+
+fn share_status(share: f64, cap_share: f64) -> (crate::theme::Style, &'static str) {
+    if share > cap_share {
+        (YELLOW, "above configured share")
+    } else {
+        (GREEN, "within configured share")
+    }
+}
+
+fn format_ts(timestamp: DateTime<Utc>) -> String {
+    timestamp.format("%Y-%m-%d %H:%M UTC").to_string()
+}
+
+fn format_percent(value: f64) -> String {
+    if !value.is_finite() {
+        return "n/a".into();
+    }
+    let percent = value * 100.0;
+    if percent > 0.0 && percent < 10.0 {
+        format!("{percent:.1}%")
+    } else {
+        format!("{percent:.0}%")
+    }
+}
+
+fn format_tokens(n: u64) -> String {
+    if n >= 1_000_000_000 {
+        format!("{:.1}B", n as f64 / 1_000_000_000.0)
+    } else if n >= 1_000_000 {
+        format!("{:.1}M", n as f64 / 1_000_000.0)
+    } else if n >= 1_000 {
+        format!("{:.1}k", n as f64 / 1_000.0)
+    } else {
+        n.to_string()
+    }
+}
+
+fn one_line(text: &str, max_chars: usize) -> String {
+    let compact = text.split_whitespace().collect::<Vec<_>>().join(" ");
+    if compact.chars().count() <= max_chars {
+        return compact;
+    }
+    let mut out: String = compact.chars().take(max_chars.saturating_sub(1)).collect();
+    out.push('…');
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ts(day: u32) -> String {
+        format!("2026-07-{day:02}T12:00:00Z")
+    }
+
+    fn turn(day: u32, model: &str, tokens: u64) -> ScorecardTurn {
+        ScorecardTurn {
+            timestamp: ts(day),
+            repo: "/repo/demo".into(),
+            branch: "feature".into(),
+            session_id: format!("s{day}"),
+            session_path: format!(".sessions/s{day}.jsonl"),
+            backend: "openrouter".into(),
+            model: model.into(),
+            input_tokens: tokens / 2,
+            output_tokens: tokens - tokens / 2,
+            total_tokens: tokens,
+        }
+    }
+
+    #[test]
+    fn model_match_defaults_find_fable_and_claude() {
+        let config = FableUsageConfig::default();
+        assert!(is_fable_model(&config, "anthropic/claude-fable-5-20260701"));
+        assert!(!is_fable_model(&config, "anthropic/claude-sonnet-4.5"));
+        assert!(is_claude_model(&config, "anthropic/claude-sonnet-4.5"));
+    }
+
+    #[test]
+    fn weekly_report_filters_to_configured_week_and_cap() {
+        let config = FableUsageConfig {
+            weekly_token_budget: Some(100_000),
+            ..Default::default()
+        };
+        let turns = vec![
+            turn(1, "anthropic/claude-fable-5", 20_000),
+            turn(2, "anthropic/claude-sonnet-4.5", 30_000),
+            turn(8, "anthropic/claude-fable-5", 99_000),
+        ];
+        let now = DateTime::parse_from_rfc3339("2026-07-04T12:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        let report = build_report(None, None, &turns, &config, now);
+
+        assert_eq!(report.fable.total_tokens, 20_000);
+        assert_eq!(report.claude.total_tokens, 50_000);
+        assert_eq!(report.other_claude.total_tokens, 30_000);
+        assert_eq!(report.fable_cap_tokens, Some(50_000));
+        assert_eq!(report.fable_share_of_claude().unwrap(), 0.4);
+    }
+
+    #[test]
+    fn sunday_week_start_changes_window() {
+        let config = FableUsageConfig {
+            week_starts_on: "sunday".into(),
+            ..Default::default()
+        };
+        let now = DateTime::parse_from_rfc3339("2026-07-04T12:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        let report = build_report(None, None, &[], &config, now);
+
+        assert_eq!(
+            report.window_start,
+            DateTime::parse_from_rfc3339("2026-06-28T00:00:00Z")
+                .unwrap()
+                .with_timezone(&Utc)
+        );
+    }
+
+    #[test]
+    fn footer_shows_configured_cap_when_available() {
+        let config = FableUsageConfig {
+            weekly_token_budget: Some(100_000),
+            ..Default::default()
+        };
+        let now = DateTime::parse_from_rfc3339("2026-07-04T12:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        let report = build_report(
+            None,
+            None,
+            &[turn(1, "anthropic/claude-fable-5", 25_000)],
+            &config,
+            now,
+        );
+
+        assert_eq!(
+            format_footer_suffix_for_report(&report),
+            "Fable 25.0k / 50.0k wk (50%)"
+        );
+    }
+}

--- a/src/fix_loop.rs
+++ b/src/fix_loop.rs
@@ -7,11 +7,11 @@ use crate::test_integration::{
     format_test_failure_feedback, run_selected_tests, run_tests, smart_test_selection, TestResult,
 };
 
-const RESET: &str = "\x1b[0m";
-const DIM: &str = "\x1b[2m";
-const GREEN: &str = "\x1b[32m";
-const RED: &str = "\x1b[31m";
-const YELLOW: &str = "\x1b[33m";
+const RESET: crate::theme::Style = crate::theme::RESET;
+const DIM: crate::theme::Style = crate::theme::MUTED;
+const GREEN: crate::theme::Style = crate::theme::SUCCESS;
+const RED: crate::theme::Style = crate::theme::ERROR;
+const YELLOW: crate::theme::Style = crate::theme::WARN;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum FixTestScope {

--- a/src/input.rs
+++ b/src/input.rs
@@ -204,9 +204,7 @@ fn render_input(
     s.push_str(prompt);
     s.push_str(&display);
     if !ghost.is_empty() {
-        s.push_str(MUTED);
-        s.push_str(&ghost);
-        s.push_str(RESET);
+        s.push_str(&format!("{MUTED}{ghost}{RESET}"));
     }
 
     if matches.is_empty() {

--- a/src/input.rs
+++ b/src/input.rs
@@ -124,24 +124,6 @@ fn render_value(value: &str) -> String {
 /// Maximum number of command rows shown in the completion menu at once.
 const MENU_MAX_ROWS: usize = 8;
 
-/// Visible width of a string, ignoring ANSI escape sequences (`ESC [ … m`).
-fn visible_width(s: &str) -> usize {
-    let mut n = 0;
-    let mut in_esc = false;
-    for ch in s.chars() {
-        if in_esc {
-            if ch == 'm' {
-                in_esc = false;
-            }
-        } else if ch == '\x1b' {
-            in_esc = true;
-        } else {
-            n += 1;
-        }
-    }
-    n
-}
-
 /// Slash-commands the current line is a prefix of, for the completion menu.
 /// Empty when: not a `/`-line, the cursor isn't at the end, completion was
 /// dismissed, or the only match is exactly what's already typed.
@@ -308,7 +290,7 @@ fn read_plain_outcome(
     write!(out, "{prompt}")?;
     out.flush()?;
     crossterm::terminal::enable_raw_mode()?;
-    let prompt_cols = visible_width(prompt);
+    let prompt_cols = crate::theme::visible_len(prompt);
     let term_cols = crossterm::terminal::size()
         .map(|(c, _)| c as usize)
         .unwrap_or(80);
@@ -595,8 +577,8 @@ mod tests {
 
     #[test]
     fn visible_width_ignores_ansi() {
-        assert_eq!(visible_width("  \x1b[96m❯\x1b[0m "), 4);
-        assert_eq!(visible_width("abc"), 3);
+        assert_eq!(crate::theme::visible_len("  \x1b[96m❯\x1b[0m "), 4);
+        assert_eq!(crate::theme::visible_len("abc"), 3);
     }
 
     #[test]

--- a/src/iterate_loop.rs
+++ b/src/iterate_loop.rs
@@ -19,11 +19,11 @@ use crate::session_turn::{run_user_turn, TurnOptions};
 use crate::shipcheck::collect_shipcheck;
 use crate::tools::run_evaluation;
 
-const RESET: &str = "\x1b[0m";
-const DIM: &str = "\x1b[2m";
-const GREEN: &str = "\x1b[32m";
-const RED: &str = "\x1b[31m";
-const YELLOW: &str = "\x1b[33m";
+const RESET: crate::theme::Style = crate::theme::RESET;
+const DIM: crate::theme::Style = crate::theme::MUTED;
+const GREEN: crate::theme::Style = crate::theme::SUCCESS;
+const RED: crate::theme::Style = crate::theme::ERROR;
+const YELLOW: crate::theme::Style = crate::theme::WARN;
 
 /// Upper bound on iterations regardless of config/flags — a runaway guard, since
 /// each round costs a generator turn plus a critic run.

--- a/src/loader.rs
+++ b/src/loader.rs
@@ -4,11 +4,10 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use crate::config::LoaderStyle;
-
-const DIM: &str = "\x1b[2m";
-const RESET: &str = "\x1b[0m";
+use crate::theme::{ascii_enabled, colors_enabled, MUTED, RESET};
 
 const SPINNER_FRAMES: &[&str] = &["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
+const ASCII_SPINNER_FRAMES: &[&str] = &["-", "\\", "|", "/"];
 const GRADIENT_COLORS: &[&str] = &[
     "\x1b[38;5;240m",
     "\x1b[38;5;245m",
@@ -82,14 +81,26 @@ impl Drop for Loader {
 
 fn draw(frame: usize, text: &str, style: LoaderStyle) {
     let mut out = std::io::stdout();
+    // Gradient builds raw 256-color codes directly (not via `Style`), so it
+    // needs an explicit NO_COLOR fallback: render as the Minimal style instead.
+    let style = if style == LoaderStyle::Gradient && !colors_enabled() {
+        LoaderStyle::Minimal
+    } else {
+        style
+    };
     match style {
         LoaderStyle::Minimal => {
             let dots = ["·", "··", "···"];
-            let _ = write!(out, "\r{DIM}{text}{}{RESET}", dots[frame % 3]);
+            let _ = write!(out, "\r{MUTED}{text}{}{RESET}", dots[frame % 3]);
         }
         LoaderStyle::Spinner => {
-            let ch = SPINNER_FRAMES[frame % SPINNER_FRAMES.len()];
-            let _ = write!(out, "\r{DIM}{ch} {text}{RESET}");
+            let frames = if ascii_enabled() {
+                ASCII_SPINNER_FRAMES
+            } else {
+                SPINNER_FRAMES
+            };
+            let ch = frames[frame % frames.len()];
+            let _ = write!(out, "\r{MUTED}{ch} {text}{RESET}");
         }
         LoaderStyle::Gradient => {
             let len = GRADIENT_COLORS.len();
@@ -98,7 +109,7 @@ fn draw(frame: usize, text: &str, style: LoaderStyle) {
                 s.push_str(GRADIENT_COLORS[(frame + i) % len]);
                 s.push(ch);
             }
-            s.push_str(RESET);
+            s.push_str(&RESET.to_string());
             let _ = out.write_all(s.as_bytes());
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,6 +20,7 @@ mod config;
 mod context_guard;
 mod continuation;
 mod crash_log;
+mod diff_view;
 mod fix_loop;
 mod handoff;
 mod hardware;

--- a/src/main.rs
+++ b/src/main.rs
@@ -77,11 +77,11 @@ use crate::tools::{build_tools_for_names, select_tool_names};
 use crate::turn_checkpoint::CheckpointStack;
 use crate::warmup::warmup;
 
-const RESET: &str = "\x1b[0m";
-const DIM: &str = "\x1b[2m";
-const GREEN: &str = "\x1b[32m";
-const YELLOW: &str = "\x1b[33m";
-const RED: &str = "\x1b[31m";
+const RESET: crate::theme::Style = crate::theme::RESET;
+const DIM: crate::theme::Style = crate::theme::MUTED;
+const GREEN: crate::theme::Style = crate::theme::SUCCESS;
+const YELLOW: crate::theme::Style = crate::theme::WARN;
+const RED: crate::theme::Style = crate::theme::ERROR;
 
 struct CliOneShot {
     prompt: String,
@@ -334,6 +334,7 @@ fn parse_eval_args() -> Option<anyhow::Result<CliEval>> {
 
 async fn run_eval_cli(opts: CliEval) -> anyhow::Result<()> {
     let config = load_config();
+    crate::theme::init(config.display.color, config.display.ascii);
     let code = crate::agent_eval::run_eval_cli(
         &config,
         &opts.fixture_id,
@@ -388,6 +389,7 @@ async fn run_one_shot(opts: CliOneShot) -> anyhow::Result<()> {
         anyhow::bail!("one-shot prompt is empty");
     }
     let config = load_config();
+    crate::theme::init(config.display.color, config.display.ascii);
     let http = crate::openai::build_http_client();
     let backend_desc = config.backend_descriptor();
     validate(&backend_desc)?;
@@ -686,8 +688,10 @@ async fn main() -> anyhow::Result<()> {
         std::process::exit(1);
     }
     let setup_base = load_config();
+    crate::theme::init(setup_base.display.color, setup_base.display.ascii);
     let _ = setup::maybe_run_first_run_setup(&setup_base).await?;
     let config = load_config();
+    crate::theme::init(config.display.color, config.display.ascii);
     let http = crate::openai::build_http_client();
     let backend_desc = config.backend_descriptor();
     let missing_codex_login = matches!(config.backend, BackendName::OpenAiCodex)
@@ -882,7 +886,8 @@ async fn main() -> anyhow::Result<()> {
                         String::new()
                     };
                     println!(
-                        "{GREEN}✓{RESET} {DIM}continuing{RESET} {} {DIM}({} messages{path_note}){RESET}",
+                        "{GREEN}{}{RESET} {DIM}continuing{RESET} {} {DIM}({} messages{path_note}){RESET}",
+                        crate::theme::OK,
                         id,
                         state.messages.len()
                     );
@@ -918,7 +923,13 @@ async fn main() -> anyhow::Result<()> {
         println!();
         println!("{}", crate::theme::fade_header("you"));
         let input = match plain_read_line_with_history_outcome(
-            format!("{}{}❯{} ", crate::theme::PAD, crate::theme::ACCENT, RESET),
+            format!(
+                "{}{}{}{} ",
+                crate::theme::PAD,
+                crate::theme::ACCENT,
+                crate::theme::PROMPT_CHAR,
+                RESET
+            ),
             input_history.entries().to_vec(),
             command_names.clone(),
         )
@@ -945,7 +956,7 @@ async fn main() -> anyhow::Result<()> {
 
         if state.config.slash_commands && trimmed.starts_with('/') {
             if let Err(e) = dispatch(trimmed, &mut state).await {
-                println!("  {RED}✗{RESET} {DIM}{e}{RESET}");
+                println!("  {RED}{}{RESET} {DIM}{e}{RESET}", crate::theme::FAIL);
             }
             continue;
         }
@@ -972,7 +983,7 @@ async fn main() -> anyhow::Result<()> {
         )
         .await
         {
-            println!("  {RED}✗{RESET} {DIM}{e}{RESET}");
+            println!("  {RED}{}{RESET} {DIM}{e}{RESET}", crate::theme::FAIL);
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,6 +21,7 @@ mod context_guard;
 mod continuation;
 mod crash_log;
 mod diff_view;
+mod fable_usage;
 mod fix_loop;
 mod handoff;
 mod hardware;

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,6 +28,7 @@ mod hooks;
 mod input;
 mod iterate_loop;
 mod loader;
+mod markdown;
 mod mcp;
 mod model_system;
 mod openai;

--- a/src/markdown.rs
+++ b/src/markdown.rs
@@ -1,0 +1,565 @@
+//! Incremental inline-markdown styling for streamed assistant text.
+//!
+//! [`MarkdownInline`] sits between the raw model deltas and the answer word
+//! wrapper: it recognizes a small, high-value subset of markdown — bold,
+//! italic, inline code, ATX headings, list bullets, and fenced code blocks —
+//! and emits [`MdEvent`]s. Text events carry ANSI-styled text (the wrapper is
+//! ANSI-blind, so the injected codes never skew wrapping); `CodeStart`/`CodeEnd`
+//! are out-of-band signals the renderer turns into framing rules and a
+//! verbatim (no-wrap) region.
+//!
+//! Design notes:
+//! - **Chunk-boundary safe.** Markers can be split across deltas (`**` arriving
+//!   as `*` then `*`). Undecidable trailing runs are held in `pending` and
+//!   re-examined on the next `feed`; `finish` flushes whatever remains as
+//!   literal text.
+//! - **Conservative inline.** Emphasis uses simple flanking rules so `2 * 3`
+//!   and `snake_case` are left alone. Unclosed markers reset at the next hard
+//!   newline, so a stray `*` never bleeds styling across the whole answer.
+//! - **NO_COLOR aware for free.** Style codes come from [`crate::theme`] and
+//!   render empty when color is disabled, so markers are still *stripped* and
+//!   bullets substituted — standard rich-CLI behavior — with one code path.
+
+use crate::theme::{ACCENT, BOLD, BULLET, ITALIC, RESET};
+
+/// An event produced while parsing streamed markdown.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum MdEvent {
+    /// Styled, ready-to-wrap text (ANSI codes already injected).
+    Text(String),
+    /// Enter a fenced code block; the fence line has been consumed.
+    CodeStart { lang: String },
+    /// Leave a fenced code block.
+    CodeEnd,
+}
+
+pub struct MarkdownInline {
+    bold: bool,
+    italic: bool,
+    code: bool,
+    heading: bool,
+    in_fence: bool,
+    at_line_start: bool,
+    /// Last visible char emitted, for emphasis flanking. `'\n'` at line start.
+    prev: char,
+    /// Undecided trailing chars carried to the next `feed`.
+    pending: String,
+}
+
+impl Default for MarkdownInline {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl MarkdownInline {
+    pub fn new() -> Self {
+        Self {
+            bold: false,
+            italic: false,
+            code: false,
+            heading: false,
+            in_fence: false,
+            at_line_start: true,
+            prev: '\n',
+            pending: String::new(),
+        }
+    }
+
+    /// ANSI codes for whichever inline styles are currently active — emitted
+    /// after a `RESET` so closing one marker doesn't drop the others.
+    fn active_codes(&self) -> String {
+        let mut s = String::new();
+        if self.heading {
+            s.push_str(&format!("{BOLD}{ACCENT}"));
+        }
+        if self.bold {
+            s.push_str(&format!("{BOLD}"));
+        }
+        if self.italic {
+            s.push_str(&format!("{ITALIC}"));
+        }
+        if self.code {
+            s.push_str(&format!("{ACCENT}"));
+        }
+        s
+    }
+
+    fn open(&mut self, text: &mut String, code: &str) {
+        text.push_str(code);
+    }
+
+    fn close(&mut self, text: &mut String) {
+        text.push_str(&format!("{RESET}"));
+        text.push_str(&self.active_codes());
+    }
+
+    pub fn feed(&mut self, delta: &str) -> Vec<MdEvent> {
+        let mut events = Vec::new();
+        let mut text = String::new();
+        let buf: Vec<char> = self.pending.chars().chain(delta.chars()).collect();
+        self.pending.clear();
+        let mut i = 0;
+
+        'outer: while i < buf.len() {
+            let ch = buf[i];
+
+            // ---- Inside a fenced code block: raw passthrough + close watch ----
+            if self.in_fence {
+                if self.at_line_start && ch == '`' {
+                    let run = backtick_run(&buf, i);
+                    if run.end == buf.len() && run.len < 3 {
+                        self.pending = buf[i..].iter().collect();
+                        break 'outer;
+                    }
+                    if run.len >= 3 {
+                        // Need the whole fence line consumed before closing.
+                        let Some(nl) = find_newline(&buf, run.end) else {
+                            self.pending = buf[i..].iter().collect();
+                            break 'outer;
+                        };
+                        if !text.is_empty() {
+                            events.push(MdEvent::Text(std::mem::take(&mut text)));
+                        }
+                        events.push(MdEvent::CodeEnd);
+                        self.in_fence = false;
+                        self.at_line_start = true;
+                        self.prev = '\n';
+                        i = nl + 1;
+                        continue;
+                    }
+                    // 1–2 backticks then content: ordinary code text.
+                    for _ in 0..run.len {
+                        text.push('`');
+                    }
+                    self.at_line_start = false;
+                    self.prev = '`';
+                    i = run.end;
+                    continue;
+                }
+                text.push(ch);
+                self.at_line_start = ch == '\n';
+                self.prev = ch;
+                i += 1;
+                continue;
+            }
+
+            // ---- Line-start structures: fence open, heading, bullet ----
+            if self.at_line_start {
+                if ch == ' ' || ch == '\t' {
+                    // Preserve leading indentation; stay at line start so a
+                    // bullet/heading after indent is still recognized.
+                    text.push(ch);
+                    self.prev = ch;
+                    i += 1;
+                    continue;
+                }
+                if ch == '`' {
+                    let run = backtick_run(&buf, i);
+                    if run.end == buf.len() && run.len < 3 {
+                        self.pending = buf[i..].iter().collect();
+                        break 'outer;
+                    }
+                    if run.len >= 3 {
+                        let Some(nl) = find_newline(&buf, run.end) else {
+                            self.pending = buf[i..].iter().collect();
+                            break 'outer;
+                        };
+                        let lang: String = buf[run.end..nl].iter().collect();
+                        if !text.is_empty() {
+                            events.push(MdEvent::Text(std::mem::take(&mut text)));
+                        }
+                        events.push(MdEvent::CodeStart {
+                            lang: lang.trim().to_string(),
+                        });
+                        self.in_fence = true;
+                        self.at_line_start = true;
+                        self.prev = '\n';
+                        i = nl + 1;
+                        continue;
+                    }
+                    // 1–2 backticks: fall through to inline code handling.
+                }
+                if ch == '#' {
+                    let hashes = hash_run(&buf, i);
+                    if hashes.end == buf.len() {
+                        self.pending = buf[i..].iter().collect();
+                        break 'outer;
+                    }
+                    if hashes.len <= 6 && buf[hashes.end] == ' ' {
+                        self.heading = true;
+                        self.open(&mut text, &format!("{BOLD}{ACCENT}"));
+                        self.at_line_start = false;
+                        self.prev = ' ';
+                        i = hashes.end + 1;
+                        continue;
+                    }
+                    // Not a heading (e.g. "#tag"): emit hashes literally below.
+                }
+                if ch == '-' || ch == '*' {
+                    let Some(&nxt) = buf.get(i + 1) else {
+                        self.pending = buf[i..].iter().collect();
+                        break 'outer;
+                    };
+                    if nxt == ' ' {
+                        text.push_str(&format!("{ACCENT}{BULLET}{RESET} "));
+                        self.at_line_start = false;
+                        self.prev = ' ';
+                        i += 2;
+                        continue;
+                    }
+                    // Not a bullet: `*` may still open emphasis below.
+                }
+            }
+
+            // ---- Inside an inline code span: only backtick / newline matter ----
+            if self.code {
+                match ch {
+                    '`' => {
+                        self.code = false;
+                        self.close(&mut text);
+                        self.prev = '`';
+                        self.at_line_start = false;
+                        i += 1;
+                    }
+                    '\n' => {
+                        self.reset_line_styles(&mut text);
+                        text.push('\n');
+                        self.at_line_start = true;
+                        self.prev = '\n';
+                        i += 1;
+                    }
+                    _ => {
+                        text.push(ch);
+                        self.prev = ch;
+                        self.at_line_start = false;
+                        i += 1;
+                    }
+                }
+                continue;
+            }
+
+            // ---- Inline styling ----
+            match ch {
+                '\n' => {
+                    self.reset_line_styles(&mut text);
+                    text.push('\n');
+                    self.at_line_start = true;
+                    self.prev = '\n';
+                    i += 1;
+                }
+                '`' => {
+                    self.code = true;
+                    self.open(&mut text, &format!("{ACCENT}"));
+                    self.prev = '`';
+                    self.at_line_start = false;
+                    i += 1;
+                }
+                '*' => {
+                    let Some(&nxt) = buf.get(i + 1) else {
+                        self.pending = buf[i..].iter().collect();
+                        break 'outer;
+                    };
+                    if nxt == '*' {
+                        self.toggle_bold(&mut text);
+                        self.prev = '*';
+                        self.at_line_start = false;
+                        i += 2;
+                    } else {
+                        if !self.try_emphasis('*', nxt, &mut text) {
+                            text.push('*');
+                        }
+                        self.prev = '*';
+                        self.at_line_start = false;
+                        i += 1;
+                    }
+                }
+                '_' => {
+                    let Some(&nxt) = buf.get(i + 1) else {
+                        self.pending = buf[i..].iter().collect();
+                        break 'outer;
+                    };
+                    if !self.try_emphasis('_', nxt, &mut text) {
+                        text.push('_');
+                    }
+                    self.prev = '_';
+                    self.at_line_start = false;
+                    i += 1;
+                }
+                _ => {
+                    text.push(ch);
+                    self.prev = ch;
+                    self.at_line_start = false;
+                    i += 1;
+                }
+            }
+        }
+
+        if !text.is_empty() {
+            events.push(MdEvent::Text(text));
+        }
+        events
+    }
+
+    pub fn finish(&mut self) -> Vec<MdEvent> {
+        let mut events = Vec::new();
+        let mut text = String::new();
+        // Any undecided markers become literal text at end of stream.
+        if !self.pending.is_empty() {
+            text.push_str(&std::mem::take(&mut self.pending));
+        }
+        self.reset_line_styles(&mut text);
+        if !text.is_empty() {
+            events.push(MdEvent::Text(text));
+        }
+        if self.in_fence {
+            events.push(MdEvent::CodeEnd);
+            self.in_fence = false;
+        }
+        events
+    }
+
+    fn reset_line_styles(&mut self, text: &mut String) {
+        if self.bold || self.italic || self.code || self.heading {
+            text.push_str(&format!("{RESET}"));
+            self.bold = false;
+            self.italic = false;
+            self.code = false;
+            self.heading = false;
+        }
+    }
+
+    fn toggle_bold(&mut self, text: &mut String) {
+        if self.bold {
+            self.bold = false;
+            self.close(text);
+        } else {
+            self.bold = true;
+            self.open(text, &format!("{BOLD}"));
+        }
+    }
+
+    /// Attempt to open or close emphasis at a `*`/`_` marker using simple
+    /// flanking rules. Returns whether the marker was consumed as emphasis
+    /// (vs. left as a literal character). `next` is the following char.
+    fn try_emphasis(&mut self, marker: char, next: char, text: &mut String) -> bool {
+        if self.italic {
+            // Close only when the marker hugs the end of a word.
+            if !self.prev.is_whitespace() {
+                self.italic = false;
+                self.close(text);
+                return true;
+            }
+            false
+        } else {
+            let prev_ok =
+                self.prev == '\n' || self.prev.is_whitespace() || self.prev.is_ascii_punctuation();
+            let next_ok = !next.is_whitespace();
+            // `_` must not sit inside a word (protects snake_case).
+            let underscore_intraword =
+                marker == '_' && self.prev.is_alphanumeric() && next.is_alphanumeric();
+            if prev_ok && next_ok && !underscore_intraword {
+                self.italic = true;
+                self.open(text, &format!("{ITALIC}"));
+                true
+            } else {
+                false
+            }
+        }
+    }
+}
+
+struct Run {
+    len: usize,
+    end: usize,
+}
+
+fn backtick_run(buf: &[char], start: usize) -> Run {
+    let mut end = start;
+    while end < buf.len() && buf[end] == '`' {
+        end += 1;
+    }
+    Run {
+        len: end - start,
+        end,
+    }
+}
+
+fn hash_run(buf: &[char], start: usize) -> Run {
+    let mut end = start;
+    while end < buf.len() && buf[end] == '#' {
+        end += 1;
+    }
+    Run {
+        len: end - start,
+        end,
+    }
+}
+
+fn find_newline(buf: &[char], from: usize) -> Option<usize> {
+    (from..buf.len()).find(|&k| buf[k] == '\n')
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::ColorMode;
+
+    /// Concatenate the text of all events (ignoring fence signals).
+    fn text_of(events: &[MdEvent]) -> String {
+        events
+            .iter()
+            .filter_map(|e| match e {
+                MdEvent::Text(s) => Some(s.clone()),
+                _ => None,
+            })
+            .collect()
+    }
+
+    /// Feed `input` one char at a time (worst case) and collect all events.
+    fn feed_char_by_char(input: &str) -> Vec<MdEvent> {
+        crate::theme::init(ColorMode::Always, false);
+        let mut md = MarkdownInline::new();
+        let mut events = Vec::new();
+        for ch in input.chars() {
+            events.extend(md.feed(&ch.to_string()));
+        }
+        events.extend(md.finish());
+        events
+    }
+
+    #[test]
+    fn bold_marker_split_across_chunks() {
+        crate::theme::init(ColorMode::Always, false);
+        let mut md = MarkdownInline::new();
+        let mut events = md.feed("say **bo");
+        events.extend(md.feed("ld** now"));
+        events.extend(md.finish());
+        let out = text_of(&events);
+        assert!(out.contains("\x1b[1mbold"));
+        assert!(out.contains("say "));
+        assert!(out.contains(" now"));
+        assert!(!out.contains('*'));
+    }
+
+    #[test]
+    fn italic_with_star_and_underscore() {
+        let star = text_of(&feed_char_by_char("an *italic* word"));
+        assert!(star.contains("\x1b[3mitalic"));
+        assert!(!star.contains('*'));
+        let under = text_of(&feed_char_by_char("an _italic_ word"));
+        assert!(under.contains("\x1b[3mitalic"));
+        assert!(!under.contains('_'));
+    }
+
+    #[test]
+    fn snake_case_is_not_italicized() {
+        let out = text_of(&feed_char_by_char("call some_function_name here"));
+        assert!(out.contains("some_function_name"));
+        assert!(!out.contains("\x1b[3m"));
+    }
+
+    #[test]
+    fn math_asterisks_are_not_styled() {
+        let out = text_of(&feed_char_by_char("compute 2 * 3 * 4"));
+        assert!(out.contains("2 * 3 * 4"));
+        assert!(!out.contains("\x1b[3m"));
+    }
+
+    #[test]
+    fn inline_code_is_colored_and_closes() {
+        let out = text_of(&feed_char_by_char("run `cargo test` now"));
+        assert!(out.contains("\x1b[96mcargo test"));
+        assert!(!out.contains('`'));
+    }
+
+    #[test]
+    fn unclosed_bold_resets_at_newline() {
+        let out = text_of(&feed_char_by_char("**bold never closes\nnext line"));
+        // A RESET appears before the newline, and the second line is unstyled.
+        let lines: Vec<&str> = out.split('\n').collect();
+        assert!(lines[0].contains("\x1b[1m"));
+        assert!(lines[0].contains("\x1b[0m"));
+        assert!(!lines[1].contains("\x1b[1m"));
+    }
+
+    #[test]
+    fn unclosed_marker_flushes_literal_at_finish() {
+        // A trailing lone '*' with nothing after it stays literal.
+        let out = text_of(&feed_char_by_char("trailing star *"));
+        assert!(out.ends_with('*'));
+    }
+
+    #[test]
+    fn heading_styles_only_its_line() {
+        let out = text_of(&feed_char_by_char("## Title\nbody text"));
+        let lines: Vec<&str> = out.split('\n').collect();
+        assert!(lines[0].contains("\x1b[1m"));
+        assert!(lines[0].contains("Title"));
+        assert!(!lines[0].contains('#'));
+        assert!(!lines[1].contains("\x1b[1m"));
+        assert!(lines[1].contains("body text"));
+    }
+
+    #[test]
+    fn bullet_marker_replaced_same_visible_width() {
+        let out = text_of(&feed_char_by_char("- first item"));
+        // The "- " became "• " (bullet + space) — same 2 visible columns.
+        assert!(out.contains('•'));
+        assert!(!out.contains("- first"));
+        // Visible width of the leading marker is still 2.
+        assert_eq!(crate::theme::visible_len(&out).min(2), 2);
+    }
+
+    #[test]
+    fn fenced_block_emits_start_and_end_with_language() {
+        let events = feed_char_by_char("before\n```rust\nlet x = 1;\n```\nafter");
+        assert!(events
+            .iter()
+            .any(|e| matches!(e, MdEvent::CodeStart { lang } if lang == "rust")));
+        assert!(events.iter().any(|e| matches!(e, MdEvent::CodeEnd)));
+        // The fence lines themselves are not emitted as text.
+        let out = text_of(&events);
+        assert!(!out.contains("```"));
+        assert!(out.contains("let x = 1;"));
+        assert!(out.contains("before"));
+        assert!(out.contains("after"));
+    }
+
+    #[test]
+    fn fence_backticks_split_across_chunks() {
+        crate::theme::init(ColorMode::Always, false);
+        let mut md = MarkdownInline::new();
+        let mut events = md.feed("``");
+        events.extend(md.feed("`py\ncode\n```\n"));
+        events.extend(md.finish());
+        assert!(events
+            .iter()
+            .any(|e| matches!(e, MdEvent::CodeStart { lang } if lang == "py")));
+        assert!(events.iter().any(|e| matches!(e, MdEvent::CodeEnd)));
+    }
+
+    #[test]
+    fn no_inline_styling_inside_fence() {
+        let events = feed_char_by_char("```\nnot **bold** and not _italic_\n```\n");
+        let out = text_of(&events);
+        // The markers survive verbatim inside the fence.
+        assert!(out.contains("**bold**"));
+        assert!(out.contains("_italic_"));
+        assert!(!out.contains("\x1b[1m"));
+    }
+
+    #[test]
+    fn no_color_strips_markers_without_escapes() {
+        crate::theme::init(ColorMode::Never, false);
+        let mut md = MarkdownInline::new();
+        let mut events = md.feed("**bold** and `code` and # not-heading");
+        events.extend(md.finish());
+        let out = text_of(&events);
+        assert!(!out.contains('\x1b'));
+        assert!(out.contains("bold"));
+        assert!(out.contains("code"));
+        assert!(!out.contains("**"));
+        crate::theme::init(ColorMode::Always, false);
+    }
+}

--- a/src/model_system.rs
+++ b/src/model_system.rs
@@ -143,7 +143,6 @@ pub struct ModelRef {
 }
 
 impl ModelRef {
-    #[cfg(test)]
     pub fn parse_spec(spec: &str) -> Option<Self> {
         let (backend, model) = spec.trim().split_once(':')?;
         let backend = BackendName::parse(backend.trim())?;
@@ -233,6 +232,8 @@ pub struct ModelSystemConfig {
     #[serde(default)]
     pub enabled: bool,
     #[serde(default)]
+    pub planner: Option<ModelRef>,
+    #[serde(default)]
     pub selector: Option<ModelRef>,
     #[serde(default)]
     pub orchestrators: ModelTierSet,
@@ -246,7 +247,8 @@ pub struct ModelSystemConfig {
 
 impl ModelSystemConfig {
     pub fn any_configured(&self) -> bool {
-        self.selector.is_some()
+        self.planner.is_some()
+            || self.selector.is_some()
             || self.orchestrators.any_configured()
             || self.coders.any_configured()
             || self.reviewers.any_configured()

--- a/src/planner.rs
+++ b/src/planner.rs
@@ -11,8 +11,15 @@
 //! the system prompt forbids prescribing files, APIs, or code, because premature
 //! technical detail in a spec cascades into downstream implementation errors.
 
+use anyhow::{anyhow, Result};
 use chrono::Utc;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::collections::HashSet;
+use std::fs;
 use std::path::{Path, PathBuf};
+
+use crate::model_system::{EffortLevel, ModelRef, ModelSystemConfig, TaskComplexity};
 
 /// Top-level sections every spec must contain, in order.
 const SPEC_SECTIONS: &[&str] = &[
@@ -30,6 +37,113 @@ pub fn default_spec_path(workspace_root: &str) -> PathBuf {
     Path::new(workspace_root)
         .join(".small-harness")
         .join("spec.md")
+}
+
+/// Where routed plans are stored: `<workspace>/.small-harness/plan.json`.
+pub fn default_routed_plan_path(workspace_root: &str) -> PathBuf {
+    Path::new(workspace_root)
+        .join(".small-harness")
+        .join("plan.json")
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum PlanTaskStatus {
+    Pending,
+    Running,
+    Done,
+    Failed,
+    Skipped,
+}
+
+impl PlanTaskStatus {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Pending => "pending",
+            Self::Running => "running",
+            Self::Done => "done",
+            Self::Failed => "failed",
+            Self::Skipped => "skipped",
+        }
+    }
+}
+
+fn default_plan_version() -> u8 {
+    1
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RoutedPlan {
+    #[serde(default = "default_plan_version")]
+    pub version: u8,
+    pub goal: String,
+    pub created_at: String,
+    #[serde(default)]
+    pub planner: Option<ModelRef>,
+    pub tasks: Vec<RoutedPlanTask>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RoutedPlanTask {
+    pub id: String,
+    pub title: String,
+    pub prompt: String,
+    #[serde(default = "default_task_role")]
+    pub role: String,
+    pub complexity: TaskComplexity,
+    #[serde(default)]
+    pub depends_on: Vec<String>,
+    #[serde(default)]
+    pub acceptance: Vec<String>,
+    #[serde(default)]
+    pub assigned_model: Option<ModelRef>,
+    #[serde(default)]
+    pub effort: Option<EffortLevel>,
+    #[serde(default = "default_task_status")]
+    pub status: PlanTaskStatus,
+    #[serde(default)]
+    pub result: Option<String>,
+    #[serde(default)]
+    pub last_error: Option<String>,
+}
+
+fn default_task_role() -> String {
+    "code".into()
+}
+
+fn default_task_status() -> PlanTaskStatus {
+    PlanTaskStatus::Pending
+}
+
+pub fn save_routed_plan(path: &Path, plan: &RoutedPlan) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        if !parent.as_os_str().is_empty() {
+            fs::create_dir_all(parent)?;
+        }
+    }
+    let body = serde_json::to_string_pretty(plan)?;
+    fs::write(path, format!("{body}\n"))?;
+    Ok(())
+}
+
+pub fn load_routed_plan(path: &Path) -> Result<RoutedPlan> {
+    let body = fs::read_to_string(path).with_context_path("reading routed plan", path)?;
+    serde_json::from_str(&body).with_context_path("parsing routed plan JSON", path)
+}
+
+trait PathContext<T> {
+    fn with_context_path(self, action: &str, path: &Path) -> Result<T>;
+}
+
+impl<T, E> PathContext<T> for std::result::Result<T, E>
+where
+    E: std::error::Error + Send + Sync + 'static,
+{
+    fn with_context_path(self, action: &str, path: &Path) -> Result<T> {
+        self.map_err(|e| anyhow!("{action} {}: {e}", path.display()))
+    }
 }
 
 /// System prompt: fixes the section contract and forbids premature technical
@@ -68,6 +182,341 @@ pub fn render_planner_prompt(intent: &str) -> String {
     out.push_str("Intent:\n");
     out.push_str(intent.trim());
     out
+}
+
+pub fn routed_planner_system_prompt() -> String {
+    [
+        "You are the planning agent for a complexity-aware Small Harness execution layer.",
+        "Break one software goal into a small, ordered task graph for coding agents.",
+        "Return ONLY JSON, with no markdown, prose, or code fence.",
+        "Use this exact top-level shape:",
+        "{\"goal\":\"...\",\"tasks\":[{\"id\":\"short-kebab-id\",\"title\":\"...\",\"prompt\":\"...\",\"role\":\"investigate|code|review|verify|docs\",\"complexity\":\"low|medium|high\",\"dependsOn\":[\"id\"],\"acceptance\":[\"observable criterion\"],\"effort\":\"none|minimal|low|medium|high|xhigh|max|null\"}]}",
+        "Low complexity means isolated edits, simple docs, straightforward tests, or narrow investigation.",
+        "Medium complexity means multi-file implementation, moderate ambiguity, or tests plus code changes.",
+        "High complexity means architecture, auth/security, broad refactors, migrations, concurrency, reliability-sensitive work, or tasks where mistakes are expensive.",
+        "Make dependencies explicit. Do not create circular dependencies. Keep task ids stable and short.",
+        "Each prompt must be self-contained enough for an executor, but should not force exact files or APIs unless the user's request already named them.",
+        "Prefer 3-8 tasks. Use high complexity sparingly.",
+    ]
+    .join("\n")
+}
+
+pub fn render_routed_planner_prompt(
+    intent: &str,
+    stack: &ModelSystemConfig,
+    planner: Option<&ModelRef>,
+) -> String {
+    let mut out = String::new();
+    out.push_str("Create a routed execution plan for this goal.\n\nGoal:\n");
+    out.push_str(intent.trim());
+    out.push_str("\n\nConfigured execution layer:\n");
+    append_model_line(&mut out, "planner", planner);
+    append_model_line(&mut out, "selector", stack.selector.as_ref());
+    append_model_line(
+        &mut out,
+        "orchestrator.low",
+        stack.orchestrators.low.as_ref(),
+    );
+    append_model_line(
+        &mut out,
+        "orchestrator.medium",
+        stack.orchestrators.medium.as_ref(),
+    );
+    append_model_line(
+        &mut out,
+        "orchestrator.high",
+        stack.orchestrators.high.as_ref(),
+    );
+    append_model_line(&mut out, "coder.low", stack.coders.low.as_ref());
+    append_model_line(&mut out, "coder.medium", stack.coders.medium.as_ref());
+    append_model_line(&mut out, "coder.high", stack.coders.high.as_ref());
+    append_model_line(&mut out, "review.play", stack.reviewers.play.as_ref());
+    append_model_line(
+        &mut out,
+        "review.production",
+        stack.reviewers.production.as_ref(),
+    );
+    append_model_line(&mut out, "security", stack.security_reviewer.as_ref());
+    out.push_str("\nAssign each task a complexity based on the configured coder tiers. Do not include tasks that cannot be executed by the configured stack unless they are unavoidable.\n");
+    out
+}
+
+fn append_model_line(out: &mut String, label: &str, model: Option<&ModelRef>) {
+    out.push_str("- ");
+    out.push_str(label);
+    out.push_str(": ");
+    match model {
+        Some(model) => out.push_str(&model.detail()),
+        None => out.push_str("not configured"),
+    }
+    out.push('\n');
+}
+
+pub fn parse_routed_plan(
+    text: &str,
+    fallback_goal: &str,
+    planner: Option<ModelRef>,
+    stack: &ModelSystemConfig,
+) -> Result<RoutedPlan> {
+    let value = if let Ok(value) = serde_json::from_str::<Value>(text.trim()) {
+        value
+    } else {
+        let Some(json) = extract_first_json_object(text) else {
+            return Err(anyhow!("planner did not return a JSON routed plan"));
+        };
+        serde_json::from_str::<Value>(json)
+            .map_err(|e| anyhow!("planner returned invalid routed-plan JSON: {e}"))?
+    };
+    routed_plan_from_value(&value, fallback_goal, planner, stack)
+}
+
+fn routed_plan_from_value(
+    value: &Value,
+    fallback_goal: &str,
+    planner: Option<ModelRef>,
+    stack: &ModelSystemConfig,
+) -> Result<RoutedPlan> {
+    let obj = value
+        .as_object()
+        .ok_or_else(|| anyhow!("routed plan must be a JSON object"))?;
+    let goal = obj
+        .get("goal")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| fallback_goal.trim())
+        .to_string();
+    if goal.is_empty() {
+        return Err(anyhow!("routed plan goal is empty"));
+    }
+    let raw_tasks = obj
+        .get("tasks")
+        .and_then(Value::as_array)
+        .ok_or_else(|| anyhow!("routed plan must include a tasks array"))?;
+    if raw_tasks.is_empty() {
+        return Err(anyhow!("routed plan must include at least one task"));
+    }
+
+    let mut tasks = Vec::new();
+    let mut ids = HashSet::new();
+    for (index, value) in raw_tasks.iter().enumerate() {
+        let task = routed_task_from_value(value, index, stack)?;
+        if !ids.insert(task.id.clone()) {
+            return Err(anyhow!("duplicate routed plan task id: {}", task.id));
+        }
+        tasks.push(task);
+    }
+
+    let known_ids: HashSet<String> = tasks.iter().map(|task| task.id.clone()).collect();
+    for task in &tasks {
+        for dep in &task.depends_on {
+            if !known_ids.contains(dep) {
+                return Err(anyhow!(
+                    "task {} depends on unknown task id {}",
+                    task.id,
+                    dep
+                ));
+            }
+            if dep == &task.id {
+                return Err(anyhow!("task {} cannot depend on itself", task.id));
+            }
+        }
+    }
+    if tasks.iter().all(|task| !task.depends_on.is_empty()) {
+        return Err(anyhow!(
+            "routed plan must include at least one task without dependencies"
+        ));
+    }
+    if let Some(id) = first_dependency_cycle(&tasks) {
+        return Err(anyhow!(
+            "routed plan has a circular dependency involving {id}"
+        ));
+    }
+
+    Ok(RoutedPlan {
+        version: 1,
+        goal,
+        created_at: Utc::now().to_rfc3339(),
+        planner,
+        tasks,
+    })
+}
+
+fn first_dependency_cycle(tasks: &[RoutedPlanTask]) -> Option<String> {
+    let mut visiting = HashSet::new();
+    let mut visited = HashSet::new();
+    for task in tasks {
+        if visit_task_for_cycle(&task.id, tasks, &mut visiting, &mut visited) {
+            return Some(task.id.clone());
+        }
+    }
+    None
+}
+
+fn visit_task_for_cycle(
+    id: &str,
+    tasks: &[RoutedPlanTask],
+    visiting: &mut HashSet<String>,
+    visited: &mut HashSet<String>,
+) -> bool {
+    if visited.contains(id) {
+        return false;
+    }
+    if !visiting.insert(id.to_string()) {
+        return true;
+    }
+    let has_cycle = tasks
+        .iter()
+        .find(|task| task.id == id)
+        .map(|task| {
+            task.depends_on
+                .iter()
+                .any(|dep| visit_task_for_cycle(dep, tasks, visiting, visited))
+        })
+        .unwrap_or(false);
+    visiting.remove(id);
+    visited.insert(id.to_string());
+    has_cycle
+}
+
+fn routed_task_from_value(
+    value: &Value,
+    index: usize,
+    stack: &ModelSystemConfig,
+) -> Result<RoutedPlanTask> {
+    let obj = value
+        .as_object()
+        .ok_or_else(|| anyhow!("task {} must be a JSON object", index + 1))?;
+    let fallback_id = format!("task-{}", index + 1);
+    let raw_id = string_field(obj, &["id", "key"])
+        .or_else(|| string_field(obj, &["title", "name"]).map(|s| sanitize_task_id(&s)))
+        .unwrap_or(fallback_id);
+    let id = sanitize_task_id(&raw_id);
+    if id.is_empty() {
+        return Err(anyhow!("task {} has an empty id", index + 1));
+    }
+    let title = string_field(obj, &["title", "name"])
+        .unwrap_or_else(|| id.replace('-', " "))
+        .trim()
+        .to_string();
+    let prompt = string_field(obj, &["prompt", "instructions", "description"])
+        .unwrap_or_else(|| title.clone())
+        .trim()
+        .to_string();
+    if prompt.is_empty() {
+        return Err(anyhow!("task {id} has an empty prompt"));
+    }
+    let role = string_field(obj, &["role", "type"])
+        .unwrap_or_else(default_task_role)
+        .trim()
+        .to_ascii_lowercase();
+    let complexity = string_field(obj, &["complexity", "difficulty"])
+        .and_then(|s| TaskComplexity::parse(&s.trim().to_ascii_lowercase()))
+        .unwrap_or(TaskComplexity::Medium);
+    let depends_on = array_strings(obj, &["dependsOn", "depends_on", "dependencies"])
+        .into_iter()
+        .map(|dep| sanitize_task_id(&dep))
+        .filter(|dep| !dep.is_empty())
+        .collect();
+    let acceptance = array_strings(
+        obj,
+        &[
+            "acceptance",
+            "acceptanceCriteria",
+            "acceptance_criteria",
+            "doneCriteria",
+            "done_criteria",
+        ],
+    );
+    let effort = string_field(obj, &["effort", "coderEffort", "coder_effort"])
+        .and_then(|s| EffortLevel::parse(&s));
+    Ok(RoutedPlanTask {
+        id,
+        title,
+        prompt,
+        role,
+        complexity,
+        depends_on,
+        acceptance,
+        assigned_model: stack.coder(complexity).cloned(),
+        effort,
+        status: PlanTaskStatus::Pending,
+        result: None,
+        last_error: None,
+    })
+}
+
+fn string_field(obj: &serde_json::Map<String, Value>, keys: &[&str]) -> Option<String> {
+    keys.iter()
+        .find_map(|key| obj.get(*key).and_then(Value::as_str))
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+}
+
+fn array_strings(obj: &serde_json::Map<String, Value>, keys: &[&str]) -> Vec<String> {
+    let Some(value) = keys.iter().find_map(|key| obj.get(*key)) else {
+        return Vec::new();
+    };
+    match value {
+        Value::Array(items) => items
+            .iter()
+            .filter_map(Value::as_str)
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(ToOwned::to_owned)
+            .collect(),
+        Value::String(text) if !text.trim().is_empty() => vec![text.trim().to_string()],
+        _ => Vec::new(),
+    }
+}
+
+fn sanitize_task_id(value: &str) -> String {
+    let mut out = String::new();
+    let mut prev_dash = false;
+    for ch in value.trim().chars() {
+        let lower = ch.to_ascii_lowercase();
+        if lower.is_ascii_alphanumeric() {
+            out.push(lower);
+            prev_dash = false;
+        } else if !prev_dash {
+            out.push('-');
+            prev_dash = true;
+        }
+    }
+    out.trim_matches('-').to_string()
+}
+
+fn extract_first_json_object(text: &str) -> Option<&str> {
+    let start = text.find('{')?;
+    let mut depth = 0usize;
+    let mut in_string = false;
+    let mut escaped = false;
+    for (offset, ch) in text[start..].char_indices() {
+        if in_string {
+            if escaped {
+                escaped = false;
+            } else if ch == '\\' {
+                escaped = true;
+            } else if ch == '"' {
+                in_string = false;
+            }
+            continue;
+        }
+        match ch {
+            '"' => in_string = true,
+            '{' => depth += 1,
+            '}' => {
+                depth = depth.saturating_sub(1);
+                if depth == 0 {
+                    let end = start + offset + ch.len_utf8();
+                    return Some(&text[start..end]);
+                }
+            }
+            _ => {}
+        }
+    }
+    None
 }
 
 /// Normalize a model draft so every required section is present. Missing
@@ -190,5 +639,67 @@ mod tests {
         let prompt = render_planner_prompt("  build a dashboard  ");
         assert!(prompt.contains("build a dashboard"));
         assert!(prompt.contains("not implementation"));
+    }
+
+    #[test]
+    fn default_routed_plan_path_is_under_small_harness() {
+        let path = default_routed_plan_path("/tmp/project");
+        assert!(path.ends_with(".small-harness/plan.json"));
+        assert!(path.starts_with("/tmp/project"));
+    }
+
+    #[test]
+    fn parses_wrapped_routed_plan_and_assigns_coder_tiers() {
+        let stack = ModelSystemConfig {
+            coders: crate::model_system::ModelTierSet {
+                low: ModelRef::parse_spec("ollama:qwen2.5:7b"),
+                high: ModelRef::parse_spec("openrouter:anthropic/claude-sonnet-4.5"),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let plan = parse_routed_plan(
+            "```json\n{\"goal\":\"ship auth\",\"tasks\":[{\"id\":\"audit\",\"title\":\"Audit auth\",\"prompt\":\"Inspect auth flow\",\"complexity\":\"low\"},{\"id\":\"implement-refresh\",\"title\":\"Implement refresh\",\"prompt\":\"Add refresh handling\",\"complexity\":\"High\",\"dependsOn\":[\"audit\"],\"acceptance\":[\"expired tokens refresh\"],\"effort\":\"high\"}]}\n```",
+            "fallback",
+            ModelRef::parse_spec("openrouter:openrouter/fusion"),
+            &stack,
+        )
+        .unwrap();
+        assert_eq!(plan.goal, "ship auth");
+        assert_eq!(plan.tasks.len(), 2);
+        assert_eq!(
+            plan.tasks[0].assigned_model.as_ref().unwrap().backend,
+            crate::backends::BackendName::Ollama
+        );
+        assert_eq!(
+            plan.tasks[1].assigned_model.as_ref().unwrap().model,
+            "anthropic/claude-sonnet-4.5"
+        );
+        assert_eq!(plan.tasks[1].effort, Some(EffortLevel::High));
+        assert_eq!(plan.tasks[1].depends_on, vec!["audit"]);
+    }
+
+    #[test]
+    fn routed_plan_rejects_unknown_dependencies() {
+        let err = parse_routed_plan(
+            r#"{"goal":"x","tasks":[{"id":"b","prompt":"do b","dependsOn":["missing"]}]}"#,
+            "fallback",
+            None,
+            &ModelSystemConfig::default(),
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("unknown task id"));
+    }
+
+    #[test]
+    fn routed_plan_rejects_cycles_even_with_a_root_task() {
+        let err = parse_routed_plan(
+            r#"{"goal":"x","tasks":[{"id":"a","prompt":"do a"},{"id":"b","prompt":"do b","dependsOn":["c"]},{"id":"c","prompt":"do c","dependsOn":["b"]}]}"#,
+            "fallback",
+            None,
+            &ModelSystemConfig::default(),
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("circular dependency"));
     }
 }

--- a/src/playground.rs
+++ b/src/playground.rs
@@ -13,13 +13,13 @@ use crate::backends::{backend, validate, BackendDescriptor, BackendName};
 use crate::config::OperatorMode;
 use crate::session_turn::{run_user_turn, TurnOptions};
 
-const RESET: &str = "\x1b[0m";
-const DIM: &str = "\x1b[2m";
-const BOLD: &str = "\x1b[1m";
-const CYAN: &str = "\x1b[36m";
-const GREEN: &str = "\x1b[32m";
-const RED: &str = "\x1b[31m";
-const YELLOW: &str = "\x1b[33m";
+const RESET: crate::theme::Style = crate::theme::RESET;
+const DIM: crate::theme::Style = crate::theme::MUTED;
+const BOLD: crate::theme::Style = crate::theme::BOLD;
+const CYAN: crate::theme::Style = crate::theme::ACCENT;
+const GREEN: crate::theme::Style = crate::theme::SUCCESS;
+const RED: crate::theme::Style = crate::theme::ERROR;
+const YELLOW: crate::theme::Style = crate::theme::WARN;
 
 pub fn list_play_fixtures() -> Vec<&'static str> {
     vec![

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -682,6 +682,8 @@ impl TuiRenderer {
             .iter()
             .filter(|s| s.get("status").and_then(Value::as_str) == Some("done"))
             .count();
+        // Leading blank: the plan block owns its own gap (no trailing blank).
+        println!();
         println!(
             "{PAD}{ACCENT}{DOT}{RESET} {BOLD}Plan{RESET}  {GRAY}{done}/{} done{RESET}",
             steps.len()
@@ -705,7 +707,6 @@ impl TuiRenderer {
             };
             println!("{PAD}  {mark} {body}");
         }
-        println!();
     }
 
     fn render_tool_result(&mut self, name: &str, call_id: &str, output: &str, depth: u32) {
@@ -797,6 +798,10 @@ impl TuiRenderer {
         if self.grouped_pending.is_empty() {
             return;
         }
+        // A block owns exactly one leading blank line and no trailing blank, so
+        // it separates cleanly from whatever came before without stacking a
+        // second blank against the next block's own leading gap.
+        println!();
         let pending = std::mem::take(&mut self.grouped_pending);
         let first = &pending[0];
         let label = label_past(&first.name);
@@ -825,7 +830,6 @@ impl TuiRenderer {
                 println!("{PAD}  {GRAY}{branch}{RESET} {TEXT}{arg_str}{RESET}{summary}");
             }
         }
-        println!();
         self.grouped_category.clear();
     }
 

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -161,6 +161,12 @@ fn summarize_output(output: &str) -> String {
 /// the panel. `feed` returns the exact text to write for a streamed chunk;
 /// `finish` flushes the trailing buffered word. State persists across chunks,
 /// so it wraps correctly even when words arrive split across deltas.
+///
+/// ANSI-blind: escape sequences (`ESC [ … m`) travel with the word they
+/// belong to but count as zero visible width, so injected color/bold codes
+/// never skew the wrap column. In verbatim mode (used for fenced code blocks)
+/// text passes through untouched except that hard newlines re-emit the gutter
+/// — long code lines wrap at the terminal edge, preserving copy-paste fidelity.
 struct StreamWrap {
     inner: usize,
     gutter: String,
@@ -169,6 +175,8 @@ struct StreamWrap {
     word: String,
     at_line_start: bool,
     need_space: bool,
+    in_escape: bool,
+    verbatim: bool,
 }
 
 impl StreamWrap {
@@ -181,7 +189,25 @@ impl StreamWrap {
             word: String::new(),
             at_line_start: true,
             need_space: false,
+            in_escape: false,
+            verbatim: false,
         }
+    }
+
+    /// Toggle verbatim (no-wrap) mode. Flushes any pending word first and
+    /// resets line state, returning the flushed remainder so nothing is lost.
+    // Wired up by the streamed-markdown code-fence handler (visual-polish step 6).
+    #[allow(dead_code)]
+    fn set_verbatim(&mut self, on: bool) -> String {
+        let mut out = String::new();
+        self.flush_word(&mut out);
+        self.verbatim = on;
+        self.col = 0;
+        self.indent = 0;
+        self.at_line_start = true;
+        self.need_space = false;
+        self.in_escape = false;
+        out
     }
 
     fn line_break(&mut self, out: &mut String, hard: bool) {
@@ -200,15 +226,29 @@ impl StreamWrap {
             return;
         }
         let word = std::mem::take(&mut self.word);
-        let wlen = word.chars().count();
+        let wlen = crate::theme::visible_len(&word);
 
         // A single token longer than the line (e.g. a URL): hard-break it.
+        // Escape sequences are emitted verbatim and never counted or split.
         if wlen > self.inner {
             if self.need_space && self.col > self.indent && self.col < self.inner {
                 out.push(' ');
                 self.col += 1;
             }
+            let mut in_esc = false;
             for ch in word.chars() {
+                if in_esc {
+                    out.push(ch);
+                    if ch == 'm' {
+                        in_esc = false;
+                    }
+                    continue;
+                }
+                if ch == '\x1b' {
+                    in_esc = true;
+                    out.push(ch);
+                    continue;
+                }
                 if self.col >= self.inner {
                     self.line_break(out, false);
                     for _ in 0..self.indent {
@@ -241,8 +281,34 @@ impl StreamWrap {
 
     fn feed(&mut self, s: &str) -> String {
         let mut out = String::new();
+        if self.verbatim {
+            // No wrapping, no word buffering: emit as-is, but re-indent each
+            // physical line with the gutter so code stays under the panel.
+            for ch in s.chars() {
+                out.push(ch);
+                if ch == '\n' {
+                    out.push_str(&self.gutter);
+                }
+            }
+            return out;
+        }
         for ch in s.chars() {
+            // An in-flight escape sequence: buffer every char with the current
+            // word (zero visible width) until the terminating `m`.
+            if self.in_escape {
+                self.word.push(ch);
+                if ch == 'm' {
+                    self.in_escape = false;
+                }
+                continue;
+            }
             match ch {
+                '\x1b' => {
+                    // Start of a zero-width escape. Buffer it with the word but
+                    // don't let it flip `at_line_start` or count as content.
+                    self.in_escape = true;
+                    self.word.push(ch);
+                }
                 '\n' => {
                     self.flush_word(&mut out);
                     self.line_break(&mut out, true);
@@ -822,6 +888,78 @@ mod tests {
         out.push_str(&w.feed("ta gamma delta"));
         out.push_str(&w.finish());
         assert_eq!(out, "alpha beta\ngamma delta");
+    }
+
+    #[test]
+    fn ansi_codes_do_not_count_toward_width() {
+        // A bold-wrapped word plus enough plain words to force a wrap; the
+        // escapes must not push any visible line past `inner`.
+        let text = "\x1b[1mbold\x1b[0m word wraps around here";
+        let lines = wrapped_lines(text, 10);
+        for line in &lines {
+            assert!(
+                crate::theme::visible_len(line) <= 10,
+                "visible width of {:?} exceeds 10",
+                line
+            );
+        }
+        // The escape codes survived intact in the output.
+        let joined = lines.join("\n");
+        assert!(joined.contains("\x1b[1m"));
+        assert!(joined.contains("\x1b[0m"));
+    }
+
+    #[test]
+    fn escape_split_across_feeds_stays_zero_width() {
+        // The escape's `\x1b[` and `1mword` arrive in separate chunks.
+        let mut w = StreamWrap::new(11, "");
+        let mut out = String::new();
+        out.push_str(&w.feed("\x1b["));
+        out.push_str(&w.feed("1mword\x1b[0m plus more"));
+        out.push_str(&w.finish());
+        for line in out.split('\n') {
+            assert!(crate::theme::visible_len(line) <= 11, "line {:?}", line);
+        }
+        assert!(out.contains("\x1b[1mword"));
+    }
+
+    #[test]
+    fn overlong_token_with_ansi_never_splits_an_escape() {
+        // A styled token longer than the line must hard-break, but never in
+        // the middle of the `\x1b[…m` sequence.
+        let mut w = StreamWrap::new(8, "");
+        let mut out = String::new();
+        out.push_str(&w.feed("\x1b[92maaaaaaaaaaaaaaaa\x1b[0m"));
+        out.push_str(&w.finish());
+        // Walk each physical line: once we see ESC we must reach its `m`
+        // before the line ends, i.e. no escape is left dangling by a break.
+        for line in out.split('\n') {
+            let mut in_esc = false;
+            for ch in line.chars() {
+                if in_esc {
+                    if ch == 'm' {
+                        in_esc = false;
+                    }
+                } else if ch == '\x1b' {
+                    in_esc = true;
+                }
+            }
+            assert!(!in_esc, "escape split across a line break: {:?}", line);
+        }
+        assert!(out.contains("\x1b[92m"));
+        assert!(out.contains("\x1b[0m"));
+    }
+
+    #[test]
+    fn verbatim_mode_passes_through_with_gutter() {
+        let mut w = StreamWrap::new(10, ">>");
+        let mut out = String::new();
+        let _ = w.set_verbatim(true);
+        // A code line far longer than `inner` is NOT wrapped; newlines re-emit
+        // the gutter.
+        out.push_str(&w.feed("let x = a_very_long_identifier_here;\nnext"));
+        out.push_str(&w.finish());
+        assert_eq!(out, "let x = a_very_long_identifier_here;\n>>next");
     }
 }
 

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -7,19 +7,22 @@ use std::time::Instant;
 use crate::agent::AgentEvent;
 use crate::config::{DisplayConfig, ToolDisplay};
 
-use crate::theme::{content_width, fade_header, ACCENT, PAD, TEXT};
+use crate::theme::{
+    content_width, fade_header, Style, ACCENT, BANG, BOLT, BRANCH, BRANCH_END, CHECK, DOT, FAIL,
+    HOOK_STOP, OK, PAD, PENDING, POINT, SUB, TEXT,
+};
 
 // Map the renderer's palette onto the shared theme. Notably `DIM` no longer
 // means ANSI faint (which was the unreadable culprit) — it's now the theme's
 // readable bright-black, same as `GRAY`.
-const RESET: &str = crate::theme::RESET;
-const BOLD: &str = crate::theme::BOLD;
-const GREEN: &str = crate::theme::SUCCESS;
-const YELLOW: &str = crate::theme::WARN;
-const RED: &str = crate::theme::ERROR;
-const GRAY: &str = crate::theme::MUTED;
-const DIM: &str = crate::theme::MUTED;
-const MAGENTA: &str = "\x1b[95m";
+const RESET: Style = crate::theme::RESET;
+const BOLD: Style = crate::theme::BOLD;
+const GREEN: Style = crate::theme::SUCCESS;
+const YELLOW: Style = crate::theme::WARN;
+const RED: Style = crate::theme::ERROR;
+const GRAY: Style = crate::theme::MUTED;
+const DIM: Style = crate::theme::MUTED;
+const MAGENTA: Style = crate::theme::MAGENTA;
 
 fn trunc(s: &str, max: usize) -> String {
     if s.chars().count() > max {
@@ -94,7 +97,7 @@ fn label_noun(name: &str) -> &'static str {
     }
 }
 
-fn tool_color(name: &str) -> &'static str {
+fn tool_color(name: &str) -> Style {
     match name {
         "shell" => RED,
         "file_write" | "file_edit" => YELLOW,
@@ -504,7 +507,7 @@ impl TuiRenderer {
             let arg_str = formatter_for(name, &args);
             let indent = "  ".repeat(depth as usize);
             println!(
-                "{PAD}{indent}{DIM}↳ {name}{RESET} {GRAY}{}{RESET}",
+                "{PAD}{indent}{DIM}{SUB} {name}{RESET} {GRAY}{}{RESET}",
                 if arg_str.is_empty() {
                     String::new()
                 } else {
@@ -519,7 +522,7 @@ impl TuiRenderer {
                 let color = tool_color(name);
                 let arg_str = formatter_for(name, &args);
                 let sep = if arg_str.is_empty() { "" } else { " " };
-                println!("  {color}⚡{RESET} {DIM}{name}{sep}{arg_str}{RESET}");
+                println!("  {color}{BOLT}{RESET} {DIM}{name}{sep}{arg_str}{RESET}");
             }
             ToolDisplay::Grouped => {
                 let category = label_past(name).to_string();
@@ -574,16 +577,25 @@ impl TuiRenderer {
             .filter(|s| s.get("status").and_then(Value::as_str) == Some("done"))
             .count();
         println!(
-            "{PAD}{ACCENT}●{RESET} {BOLD}Plan{RESET}  {GRAY}{done}/{} done{RESET}",
+            "{PAD}{ACCENT}{DOT}{RESET} {BOLD}Plan{RESET}  {GRAY}{done}/{} done{RESET}",
             steps.len()
         );
         for s in steps {
             let text = s.get("step").and_then(Value::as_str).unwrap_or("");
             let status = s.get("status").and_then(Value::as_str).unwrap_or("pending");
             let (mark, body) = match status {
-                "done" => (format!("{GREEN}✔{RESET}"), format!("{GRAY}{text}{RESET}")),
-                "in_progress" => (format!("{YELLOW}▸{RESET}"), format!("{BOLD}{text}{RESET}")),
-                _ => (format!("{GRAY}○{RESET}"), format!("{GRAY}{text}{RESET}")),
+                "done" => (
+                    format!("{GREEN}{CHECK}{RESET}"),
+                    format!("{GRAY}{text}{RESET}"),
+                ),
+                "in_progress" => (
+                    format!("{YELLOW}{POINT}{RESET}"),
+                    format!("{BOLD}{text}{RESET}"),
+                ),
+                _ => (
+                    format!("{GRAY}{PENDING}{RESET}"),
+                    format!("{GRAY}{text}{RESET}"),
+                ),
             };
             println!("{PAD}  {mark} {body}");
         }
@@ -613,7 +625,7 @@ impl TuiRenderer {
             let indent = "  ".repeat(depth as usize);
             let summary = summarize_output(output);
             println!(
-                "{PAD}{indent}{DIM}↳ {name} {dur}{RESET} {GRAY}{}{RESET}",
+                "{PAD}{indent}{DIM}{SUB} {name} {dur}{RESET} {GRAY}{}{RESET}",
                 if summary.is_empty() {
                     String::new()
                 } else {
@@ -625,7 +637,7 @@ impl TuiRenderer {
 
         match self.display.tool_display {
             ToolDisplay::Emoji => {
-                println!("  {GREEN}✓{RESET} {DIM}{name} {dur}{RESET}");
+                println!("  {GREEN}{OK}{RESET} {DIM}{name} {dur}{RESET}");
             }
             ToolDisplay::Grouped => {
                 if let Some(p) = self
@@ -655,18 +667,18 @@ impl TuiRenderer {
         } else {
             String::new()
         };
-        println!("{PAD}{indent}{DIM}↳ {name} output compacted: {summary}{RESET}");
+        println!("{PAD}{indent}{DIM}{SUB} {name} output compacted: {summary}{RESET}");
     }
 
     fn render_hook_notice(&mut self, notice: &crate::hooks::HookNotice) {
         use crate::hooks::HookNoticeLevel;
 
         let (mark, label, color) = match notice.level {
-            HookNoticeLevel::Warning => ("!", "hook warning", YELLOW),
-            HookNoticeLevel::Blocked => ("✗", "hook blocked", RED),
-            HookNoticeLevel::Denied => ("✗", "hook denied", RED),
-            HookNoticeLevel::Stopped => ("■", "hook stopped", YELLOW),
-            HookNoticeLevel::Feedback => ("↳", "hook", DIM),
+            HookNoticeLevel::Warning => (BANG, "hook warning", YELLOW),
+            HookNoticeLevel::Blocked => (FAIL, "hook blocked", RED),
+            HookNoticeLevel::Denied => (FAIL, "hook denied", RED),
+            HookNoticeLevel::Stopped => (HOOK_STOP, "hook stopped", YELLOW),
+            HookNoticeLevel::Feedback => (SUB, "hook", DIM),
         };
         println!(
             "{PAD}{color}{mark}{RESET} {DIM}{label} {}:{RESET} {}",
@@ -685,19 +697,19 @@ impl TuiRenderer {
 
         if pending.len() == 1 {
             let arg_str = formatter_for(&first.name, &first.args);
-            println!("{PAD}{ACCENT}●{RESET} {BOLD}{label}{RESET}  {TEXT}{arg_str}{RESET}");
+            println!("{PAD}{ACCENT}{DOT}{RESET} {BOLD}{label}{RESET}  {TEXT}{arg_str}{RESET}");
             if let Some(out) = &first.output {
                 let summary = summarize_output(out);
                 if !summary.is_empty() {
-                    println!("{PAD}  {GRAY}└ {summary}{RESET}");
+                    println!("{PAD}  {GRAY}{BRANCH_END} {summary}{RESET}");
                 }
             }
         } else {
-            println!("{PAD}{ACCENT}●{RESET} {BOLD}{label}{RESET}");
+            println!("{PAD}{ACCENT}{DOT}{RESET} {BOLD}{label}{RESET}");
             let n = pending.len();
             for (i, p) in pending.iter().enumerate() {
                 let is_last = i == n - 1;
-                let branch = if is_last { "└" } else { "├" };
+                let branch = if is_last { BRANCH_END } else { BRANCH };
                 let arg_str = formatter_for(&p.name, &p.args);
                 let summary = p
                     .output

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -6,6 +6,7 @@ use std::time::Instant;
 
 use crate::agent::AgentEvent;
 use crate::config::{DisplayConfig, ToolDisplay};
+use crate::markdown::{MarkdownInline, MdEvent};
 
 use crate::theme::{
     content_width, fade_header, Style, ACCENT, BANG, BOLT, BRANCH, BRANCH_END, CHECK, DOT, FAIL,
@@ -196,8 +197,7 @@ impl StreamWrap {
 
     /// Toggle verbatim (no-wrap) mode. Flushes any pending word first and
     /// resets line state, returning the flushed remainder so nothing is lost.
-    // Wired up by the streamed-markdown code-fence handler (visual-polish step 6).
-    #[allow(dead_code)]
+    /// Used by the streamed-markdown code-fence handler.
     fn set_verbatim(&mut self, on: bool) -> String {
         let mut out = String::new();
         self.flush_word(&mut out);
@@ -364,9 +364,39 @@ pub struct TuiRenderer {
     /// and streaming. Holds the word-wrap state so content stays inside the
     /// panel. Closed when a tool call/reasoning interrupts or the turn ends.
     answer_wrap: Option<StreamWrap>,
+    /// Inline-markdown state for the open answer panel, paired with
+    /// `answer_wrap`. Styles bold/italic/code/headings/bullets and frames
+    /// fenced code blocks as the answer streams.
+    answer_md: Option<MarkdownInline>,
     /// The configured tool display, remembered so `/verbose off` can restore it.
     base_tool_display: ToolDisplay,
     trace_enabled: bool,
+}
+
+/// Route one markdown event to the answer wrapper: styled text flows through
+/// the wrapper; fence signals flip verbatim mode and print framing rules. Kept
+/// free-standing so it can borrow the wrapper without the whole renderer.
+fn write_md_event(out: &mut impl Write, wrap: &mut StreamWrap, ev: MdEvent) {
+    match ev {
+        MdEvent::Text(s) => {
+            let chunk = wrap.feed(&s);
+            let _ = write!(out, "{chunk}");
+        }
+        MdEvent::CodeStart { lang } => {
+            // A newline+gutter always precedes a fence, so the rule (which has
+            // no leading PAD) lands correctly under the answer gutter.
+            let flushed = wrap.set_verbatim(true);
+            let _ = write!(out, "{flushed}");
+            let _ = writeln!(out, "{}", crate::theme::code_fence_rule(&lang));
+            let _ = write!(out, "{PAD}");
+        }
+        MdEvent::CodeEnd => {
+            let flushed = wrap.set_verbatim(false);
+            let _ = write!(out, "{flushed}");
+            let _ = writeln!(out, "{}", crate::theme::code_fence_rule(""));
+            let _ = write!(out, "{PAD}{TEXT}");
+        }
+    }
 }
 
 impl TuiRenderer {
@@ -381,6 +411,7 @@ impl TuiRenderer {
             minimal_batch: BTreeMap::new(),
             reasoning_header_shown: false,
             answer_wrap: None,
+            answer_md: None,
             base_tool_display,
             trace_enabled: false,
         }
@@ -484,6 +515,13 @@ impl TuiRenderer {
             return;
         };
         let mut out = std::io::stdout();
+        // Drain any buffered markdown (unclosed markers → literal, an open
+        // fence → CodeEnd) before flushing the wrapper's trailing word.
+        if let Some(mut md) = self.answer_md.take() {
+            for ev in md.finish() {
+                write_md_event(&mut out, &mut wrap, ev);
+            }
+        }
         let tail = wrap.finish();
         let _ = write!(out, "{tail}");
         let _ = writeln!(out, "{RESET}");
@@ -528,10 +566,12 @@ impl TuiRenderer {
             // Wrap to the real content width so the answer fills the terminal
             // (like naturally-wrapped text) instead of overflowing.
             self.answer_wrap = Some(StreamWrap::new(content_width(), PAD));
+            self.answer_md = Some(MarkdownInline::new());
         }
-        if let Some(wrap) = self.answer_wrap.as_mut() {
-            let chunk = wrap.feed(delta);
-            let _ = write!(out, "{chunk}");
+        if let (Some(md), Some(wrap)) = (self.answer_md.as_mut(), self.answer_wrap.as_mut()) {
+            for ev in md.feed(delta) {
+                write_md_event(&mut out, wrap, ev);
+            }
         }
         let _ = out.flush();
     }
@@ -948,6 +988,43 @@ mod tests {
         }
         assert!(out.contains("\x1b[92m"));
         assert!(out.contains("\x1b[0m"));
+    }
+
+    #[test]
+    fn markdown_then_wrap_respects_width_with_styling() {
+        // Styled markdown streamed through MarkdownInline into StreamWrap must
+        // never produce a visible line wider than `inner`, despite the ANSI
+        // codes injected for bold/italic/code.
+        use crate::markdown::{MarkdownInline, MdEvent};
+        crate::theme::init(crate::config::ColorMode::Always, false);
+        let input =
+            "Here is **bold text** and `inline code` plus _emphasis_ that must wrap cleanly around.";
+        let mut md = MarkdownInline::new();
+        let mut wrap = StreamWrap::new(20, "");
+        let mut out = String::new();
+        for ch in input.chars() {
+            for ev in md.feed(&ch.to_string()) {
+                if let MdEvent::Text(s) = ev {
+                    out.push_str(&wrap.feed(&s));
+                }
+            }
+        }
+        for ev in md.finish() {
+            if let MdEvent::Text(s) = ev {
+                out.push_str(&wrap.feed(&s));
+            }
+        }
+        out.push_str(&wrap.finish());
+        for line in out.split('\n') {
+            assert!(
+                crate::theme::visible_len(line) <= 20,
+                "styled line {:?} exceeds width 20 (visible {})",
+                line,
+                crate::theme::visible_len(line)
+            );
+        }
+        // Styling actually happened.
+        assert!(out.contains("\x1b[1m"));
     }
 
     #[test]

--- a/src/scorecard.rs
+++ b/src/scorecard.rs
@@ -1553,7 +1553,7 @@ pub fn format_scorecard_suffix(
         return Ok(String::new());
     }
     Ok(format!(
-        " · {} turn(s) tracked · /ship pr closes scorecard",
+        "{} turn(s) tracked · /ship pr closes scorecard",
         summary.turn_count
     ))
 }

--- a/src/scorecard.rs
+++ b/src/scorecard.rs
@@ -256,6 +256,13 @@ struct ScorecardRead {
     diagnostics: ScorecardStoreDiagnostics,
 }
 
+#[derive(Debug, Clone)]
+pub struct ScorecardTurnRead {
+    pub path: Option<PathBuf>,
+    pub turns: Vec<ScorecardTurn>,
+    pub diagnostics: Option<ScorecardStoreDiagnostics>,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ScorecardResetSummary {
     pub path: PathBuf,
@@ -366,6 +373,29 @@ pub fn load_report(workspace_root: &str) -> Result<ScorecardReport> {
         Utc::now().date_naive(),
         diagnostics,
     ))
+}
+
+pub fn load_turn_records() -> Result<ScorecardTurnRead> {
+    let path = scorecard_path();
+    let (events, diagnostics) = match &path {
+        Some(path) => {
+            let read = read_events_with_diagnostics(path)?;
+            (read.events, Some(read.diagnostics))
+        }
+        None => (Vec::new(), None),
+    };
+    let turns = events
+        .into_iter()
+        .filter_map(|event| match event {
+            ScorecardEvent::Turn(turn) => Some(turn),
+            _ => None,
+        })
+        .collect();
+    Ok(ScorecardTurnRead {
+        path,
+        turns,
+        diagnostics,
+    })
 }
 
 pub fn recent_prs(limit: usize) -> Result<Vec<ScorecardPr>> {

--- a/src/scorecard.rs
+++ b/src/scorecard.rs
@@ -7,12 +7,12 @@ use std::io::{BufRead, BufReader, Write};
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
-const RESET: &str = crate::theme::RESET;
-const DIM: &str = crate::theme::MUTED;
-const GREEN: &str = crate::theme::SUCCESS;
-const YELLOW: &str = crate::theme::WARN;
-const CYAN: &str = "\x1b[36m";
-const BRIGHT_GREEN: &str = "\x1b[92m";
+const RESET: crate::theme::Style = crate::theme::RESET;
+const DIM: crate::theme::Style = crate::theme::MUTED;
+const GREEN: crate::theme::Style = crate::theme::SUCCESS;
+const YELLOW: crate::theme::Style = crate::theme::WARN;
+const CYAN: crate::theme::Style = crate::theme::ACCENT_DEEP;
+const BRIGHT_GREEN: crate::theme::Style = crate::theme::SUCCESS;
 const STORE_DIR_ENV: &str = "SMALL_HARNESS_SCORECARD_DIR";
 #[cfg(test)]
 const DEFAULT_QUALITY_PR_THRESHOLD: u8 = 80;

--- a/src/session_turn.rs
+++ b/src/session_turn.rs
@@ -110,6 +110,11 @@ impl ApprovalProvider for TracingApproval<'_> {
     }
 }
 
+/// Turn cost above which the cost part of the footer is highlighted in
+/// WARN instead of the footer's usual muted gray. Deliberately not
+/// configurable — it's a visual nudge, not a budget control.
+const TURN_COST_WARN_USD: f64 = 0.50;
+
 fn format_tokens(n: u32) -> String {
     if n >= 1000 {
         format!("{:.1}k", n as f32 / 1000.0)
@@ -123,7 +128,7 @@ fn format_path_suffix(state: &AppState) -> String {
         return String::new();
     }
     format!(
-        " · path: {} · {} paths",
+        "path: {} · {} paths",
         state.path_store.active_id(),
         state.path_store.path_count()
     )
@@ -144,10 +149,15 @@ fn format_cost_suffix(
         None => "$?".into(),
     };
     let session_prefix = if has_unknown { "≥" } else { "" };
-    format!(
-        " · {turn_part} this turn · {session_prefix}{} session",
+    let text = format!(
+        "{turn_part} this turn · {session_prefix}{} session",
         format_usd(session_usd)
-    )
+    );
+    if turn_cost.is_some_and(|c| c > TURN_COST_WARN_USD) {
+        format!("{YELLOW}{text}{GRAY}")
+    } else {
+        text
+    }
 }
 
 fn format_timing_suffix(metrics: &TurnMetrics) -> String {
@@ -156,8 +166,54 @@ fn format_timing_suffix(metrics: &TurnMetrics) -> String {
 
 fn format_effort_suffix(effort: Option<EffortLevel>) -> String {
     effort
-        .map(|effort| format!(" · effort {}", effort.as_str()))
+        .map(|effort| format!("effort {}", effort.as_str()))
         .unwrap_or_default()
+}
+
+/// Join the non-empty footer parts with a single `" · "` separator, so
+/// individual suffix builders don't each bake in their own leading
+/// separator (which used to make empty-part handling error-prone).
+#[allow(clippy::too_many_arguments)]
+fn format_footer(
+    input_tokens: u32,
+    output_tokens: u32,
+    turn_cost: Option<f64>,
+    backend_is_local: bool,
+    session_usd: f64,
+    session_cost_has_unknown: bool,
+    effort: Option<EffortLevel>,
+    metrics: &TurnMetrics,
+    path_suffix: &str,
+    scorecard_suffix: &str,
+) -> String {
+    let mut parts = vec![
+        format!("{} in", format_tokens(input_tokens)),
+        format!("{} out", format_tokens(output_tokens)),
+    ];
+    let cost = format_cost_suffix(
+        turn_cost,
+        backend_is_local,
+        session_usd,
+        session_cost_has_unknown,
+    );
+    if !cost.is_empty() {
+        parts.push(cost);
+    }
+    let effort_part = format_effort_suffix(effort);
+    if !effort_part.is_empty() {
+        parts.push(effort_part);
+    }
+    let timing = format_timing_suffix(metrics);
+    if !timing.is_empty() {
+        parts.push(timing);
+    }
+    if !path_suffix.is_empty() {
+        parts.push(path_suffix.to_string());
+    }
+    if !scorecard_suffix.is_empty() {
+        parts.push(scorecard_suffix.to_string());
+    }
+    format!("{GRAY}  {}{RESET}", parts.join(" · "))
 }
 
 fn prompt_fingerprint(
@@ -843,19 +899,19 @@ pub async fn run_user_turn(state: &mut AppState, opts: TurnOptions) -> Result<Tu
     .unwrap_or_default();
 
     println!(
-        "{GRAY}  {} in · {} out{}{}{}{}{}{RESET}",
-        format_tokens(res.input_tokens),
-        format_tokens(res.output_tokens),
-        format_cost_suffix(
+        "{}",
+        format_footer(
+            res.input_tokens,
+            res.output_tokens,
             turn_cost,
             state.config.backend.is_local(),
             state.session_usd,
-            state.session_cost_has_unknown
-        ),
-        format_effort_suffix(state.active_effort),
-        format_timing_suffix(&metrics),
-        format_path_suffix(state),
-        scorecard_suffix,
+            state.session_cost_has_unknown,
+            state.active_effort,
+            &metrics,
+            &format_path_suffix(state),
+            &scorecard_suffix,
+        )
     );
 
     Ok(TurnOutcome {
@@ -1067,10 +1123,67 @@ mod cost_tests {
     #[test]
     fn effort_suffix_renders_when_set() {
         assert_eq!(format_effort_suffix(None), "");
-        assert_eq!(
-            format_effort_suffix(Some(EffortLevel::High)),
-            " · effort high"
+        assert_eq!(format_effort_suffix(Some(EffortLevel::High)), "effort high");
+    }
+
+    #[test]
+    fn cost_above_warn_threshold_is_highlighted() {
+        let s = format_cost_suffix(Some(0.75), false, 0.75, false);
+        assert!(s.contains(&YELLOW.to_string()));
+    }
+
+    #[test]
+    fn cost_below_warn_threshold_is_not_highlighted() {
+        let s = format_cost_suffix(Some(0.10), false, 0.10, false);
+        assert!(!s.contains(&YELLOW.to_string()));
+    }
+
+    #[test]
+    fn footer_has_no_doubled_or_leading_separators_when_parts_empty() {
+        let metrics = TurnMetrics::default();
+        let footer = format_footer(1200, 87, None, true, 0.0, false, None, &metrics, "", "");
+        // Only the two always-present parts (tokens in/out) should appear,
+        // joined by exactly one " · ", with no trailing/leading separator.
+        assert!(footer.contains("1.2k in · 87 out"));
+        assert!(!footer.contains("· ·"));
+        assert!(!footer
+            .trim_start_matches(&GRAY.to_string())
+            .starts_with(" · "));
+    }
+
+    #[test]
+    fn footer_joins_all_present_parts_with_single_separator() {
+        let metrics = TurnMetrics {
+            steps: 2,
+            ttft_ms: None,
+            model_ms: 0,
+            tool_ms: 0,
+            approval_ms: 0,
+            total_ms: 1000,
+            hit_step_limit: false,
+        };
+        let footer = format_footer(
+            500,
+            120,
+            Some(0.01),
+            false,
+            0.01,
+            false,
+            Some(EffortLevel::High),
+            &metrics,
+            "path: main · 2 paths",
+            "3 turn(s) tracked · /ship pr closes scorecard",
         );
+        assert!(footer.contains("500 in · 120 out · $0.01 this turn · $0.01 session · effort high"));
+        assert!(footer.contains("path: main · 2 paths"));
+        assert!(footer.contains("3 turn(s) tracked"));
+    }
+
+    #[test]
+    fn local_backend_footer_has_no_cost_part() {
+        let metrics = TurnMetrics::default();
+        let footer = format_footer(100, 50, None, true, 0.0, false, None, &metrics, "", "");
+        assert!(!footer.contains('$'));
     }
 
     #[test]

--- a/src/session_turn.rs
+++ b/src/session_turn.rs
@@ -185,6 +185,7 @@ fn format_footer(
     metrics: &TurnMetrics,
     path_suffix: &str,
     scorecard_suffix: &str,
+    fable_suffix: &str,
 ) -> String {
     let mut parts = vec![
         format!("{} in", format_tokens(input_tokens)),
@@ -212,6 +213,9 @@ fn format_footer(
     }
     if !scorecard_suffix.is_empty() {
         parts.push(scorecard_suffix.to_string());
+    }
+    if !fable_suffix.is_empty() {
+        parts.push(fable_suffix.to_string());
     }
     format!("{GRAY}  {}{RESET}", parts.join(" · "))
 }
@@ -897,6 +901,18 @@ pub async fn run_user_turn(state: &mut AppState, opts: TurnOptions) -> Result<Tu
         state.config.scorecard.nudge_min_turns,
     )
     .unwrap_or_default();
+    let fable_suffix = if state.config.fable.enabled
+        && crate::fable_usage::is_fable_model(&state.config.fable, &state.model)
+    {
+        if state.config.scorecard.enabled {
+            crate::fable_usage::format_footer_suffix(&state.config.fable, &state.model)
+                .unwrap_or_default()
+        } else {
+            "Fable tracker off (scorecard.disabled)".to_string()
+        }
+    } else {
+        String::new()
+    };
 
     // One leading blank separates the quiet stats footer from the turn's
     // response and any checkpoint/test notices above it.
@@ -914,6 +930,7 @@ pub async fn run_user_turn(state: &mut AppState, opts: TurnOptions) -> Result<Tu
             &metrics,
             &format_path_suffix(state),
             &scorecard_suffix,
+            &fable_suffix,
         )
     );
 
@@ -1144,7 +1161,7 @@ mod cost_tests {
     #[test]
     fn footer_has_no_doubled_or_leading_separators_when_parts_empty() {
         let metrics = TurnMetrics::default();
-        let footer = format_footer(1200, 87, None, true, 0.0, false, None, &metrics, "", "");
+        let footer = format_footer(1200, 87, None, true, 0.0, false, None, &metrics, "", "", "");
         // Only the two always-present parts (tokens in/out) should appear,
         // joined by exactly one " · ", with no trailing/leading separator.
         assert!(footer.contains("1.2k in · 87 out"));
@@ -1176,16 +1193,18 @@ mod cost_tests {
             &metrics,
             "path: main · 2 paths",
             "3 turn(s) tracked · /ship pr closes scorecard",
+            "Fable 25.0k / 50.0k wk (50%)",
         );
         assert!(footer.contains("500 in · 120 out · $0.01 this turn · $0.01 session · effort high"));
         assert!(footer.contains("path: main · 2 paths"));
         assert!(footer.contains("3 turn(s) tracked"));
+        assert!(footer.contains("Fable 25.0k / 50.0k wk (50%)"));
     }
 
     #[test]
     fn local_backend_footer_has_no_cost_part() {
         let metrics = TurnMetrics::default();
-        let footer = format_footer(100, 50, None, true, 0.0, false, None, &metrics, "", "");
+        let footer = format_footer(100, 50, None, true, 0.0, false, None, &metrics, "", "", "");
         assert!(!footer.contains('$'));
     }
 

--- a/src/session_turn.rs
+++ b/src/session_turn.rs
@@ -898,6 +898,9 @@ pub async fn run_user_turn(state: &mut AppState, opts: TurnOptions) -> Result<Tu
     )
     .unwrap_or_default();
 
+    // One leading blank separates the quiet stats footer from the turn's
+    // response and any checkpoint/test notices above it.
+    println!();
     println!(
         "{}",
         format_footer(

--- a/src/session_turn.rs
+++ b/src/session_turn.rs
@@ -36,12 +36,12 @@ use crate::turn_checkpoint::{active_tools_need_checkpoints, should_push_checkpoi
 use crate::turn_trace::{ApprovalDecision, TracePayload, TurnMetrics};
 use crate::warmup::warmup;
 
-const RESET: &str = crate::theme::RESET;
-const DIM: &str = crate::theme::MUTED;
-const GREEN: &str = crate::theme::SUCCESS;
-const YELLOW: &str = crate::theme::WARN;
-const RED: &str = crate::theme::ERROR;
-const GRAY: &str = crate::theme::MUTED;
+const RESET: crate::theme::Style = crate::theme::RESET;
+const DIM: crate::theme::Style = crate::theme::MUTED;
+const GREEN: crate::theme::Style = crate::theme::SUCCESS;
+const YELLOW: crate::theme::Style = crate::theme::WARN;
+const RED: crate::theme::Style = crate::theme::ERROR;
+const GRAY: crate::theme::Style = crate::theme::MUTED;
 
 pub struct TurnOptions {
     pub user_prompt: String,

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -11,13 +11,13 @@ use crate::openai::{build_http_client, chat_oneshot, list_models, ChatMessage, C
 
 // Routed through the shared theme so the wizard matches the rest of the TUI
 // and secondary text is readable bright-black instead of ANSI faint.
-const RESET: &str = crate::theme::RESET;
-const DIM: &str = crate::theme::MUTED;
-const BOLD: &str = crate::theme::BOLD;
-const CYAN: &str = crate::theme::ACCENT;
-const GREEN: &str = crate::theme::SUCCESS;
-const YELLOW: &str = crate::theme::WARN;
-const RED: &str = crate::theme::ERROR;
+const RESET: crate::theme::Style = crate::theme::RESET;
+const DIM: crate::theme::Style = crate::theme::MUTED;
+const BOLD: crate::theme::Style = crate::theme::BOLD;
+const CYAN: crate::theme::Style = crate::theme::ACCENT;
+const GREEN: crate::theme::Style = crate::theme::SUCCESS;
+const YELLOW: crate::theme::Style = crate::theme::WARN;
+const RED: crate::theme::Style = crate::theme::ERROR;
 
 const CONFIG_PATH: &str = "agent.config.json";
 const NO_WIZARD_ENV: &str = "SMALL_HARNESS_NO_WIZARD";

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -6,21 +6,125 @@
 //! renders as washed-out, hard-to-read text on many terminals and themes — it
 //! was the main reason the old TUI looked dim. Secondary text uses bright-black
 //! (`MUTED`) instead, which stays legible on both light and dark backgrounds.
+//!
+//! Runtime switches: colors and glyphs honor a process-wide switch set once at
+//! startup by [`init`]. `Style` renders its escape code only while colors are
+//! enabled (NO_COLOR / `display.color` / non-tty aware), and `Sym` picks an
+//! ASCII fallback when `display.ascii` is set. Because both implement
+//! `Display`, every existing `format!("{ACCENT}…{RESET}")` site works
+//! unchanged.
 
-pub const RESET: &str = "\x1b[0m";
-pub const BOLD: &str = "\x1b[1m";
+use std::io::IsTerminal;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use crate::config::ColorMode;
+
+static COLORS_ENABLED: AtomicBool = AtomicBool::new(true);
+static ASCII_SYMBOLS: AtomicBool = AtomicBool::new(false);
+
+pub fn colors_enabled() -> bool {
+    COLORS_ENABLED.load(Ordering::Relaxed)
+}
+
+pub fn ascii_enabled() -> bool {
+    ASCII_SYMBOLS.load(Ordering::Relaxed)
+}
+
+/// Resolve and apply the color/glyph switches. Call once per process entry
+/// point (interactive, one-shot, eval) right after config load, before any UI
+/// output.
+pub fn init(color: ColorMode, ascii: bool) {
+    let no_color = std::env::var_os("NO_COLOR").is_some_and(|v| !v.is_empty());
+    let term_dumb = std::env::var("TERM").map(|t| t == "dumb").unwrap_or(false);
+    let is_tty = std::io::stdout().is_terminal();
+    COLORS_ENABLED.store(
+        resolve_color_mode(color, no_color, term_dumb, is_tty),
+        Ordering::Relaxed,
+    );
+    ASCII_SYMBOLS.store(ascii, Ordering::Relaxed);
+}
+
+/// Pure color-mode resolution (kept side-effect-free so precedence is unit
+/// testable). `always` deliberately overrides NO_COLOR: per no-color.org,
+/// user-level configuration that explicitly requests color wins.
+pub fn resolve_color_mode(mode: ColorMode, no_color: bool, term_dumb: bool, is_tty: bool) -> bool {
+    match mode {
+        ColorMode::Always => true,
+        ColorMode::Never => false,
+        ColorMode::Auto => !no_color && !term_dumb && is_tty,
+    }
+}
+
+/// An ANSI style that renders its escape code only while colors are enabled.
+/// Zero-cost to copy; interpolates directly in `format!` strings.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Style(&'static str);
+
+impl std::fmt::Display for Style {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if colors_enabled() {
+            f.write_str(self.0)
+        } else {
+            Ok(())
+        }
+    }
+}
+
+pub const RESET: Style = Style("\x1b[0m");
+pub const BOLD: Style = Style("\x1b[1m");
+// Used by the streamed-markdown state machine (visual-polish step 6).
+#[allow(dead_code)]
+pub const ITALIC: Style = Style("\x1b[3m");
 
 /// Accent — prompts, headers, the active step. Bright cyan.
-pub const ACCENT: &str = "\x1b[96m";
+pub const ACCENT: Style = Style("\x1b[96m");
 /// A slightly deeper accent for large fills (the logo).
-pub const ACCENT_DEEP: &str = "\x1b[36m";
+pub const ACCENT_DEEP: Style = Style("\x1b[36m");
 /// Primary content: the terminal's default foreground (max contrast).
-pub const TEXT: &str = "\x1b[0m";
+pub const TEXT: Style = Style("\x1b[0m");
 /// Secondary text — labels, summaries, hints. Bright-black, NOT faint.
-pub const MUTED: &str = "\x1b[90m";
-pub const SUCCESS: &str = "\x1b[92m";
-pub const WARN: &str = "\x1b[93m";
-pub const ERROR: &str = "\x1b[91m";
+pub const MUTED: Style = Style("\x1b[90m");
+pub const SUCCESS: Style = Style("\x1b[92m");
+pub const WARN: Style = Style("\x1b[93m");
+pub const ERROR: Style = Style("\x1b[91m");
+pub const MAGENTA: Style = Style("\x1b[95m");
+
+/// A glyph with an ASCII fallback, selected by the `display.ascii` switch.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Sym(&'static str, &'static str);
+
+impl std::fmt::Display for Sym {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(if ascii_enabled() { self.1 } else { self.0 })
+    }
+}
+
+pub const OK: Sym = Sym("✓", "+");
+pub const FAIL: Sym = Sym("✗", "x");
+pub const POINT: Sym = Sym("▸", ">");
+pub const DOT: Sym = Sym("●", "*");
+pub const CHECK: Sym = Sym("✔", "+");
+pub const PENDING: Sym = Sym("○", "o");
+pub const SUB: Sym = Sym("↳", ">");
+pub const WARN_MARK: Sym = Sym("▲", "!");
+// Used by the streamed-markdown state machine for `- `/`* ` list items
+// (visual-polish step 6).
+#[allow(dead_code)]
+pub const BULLET: Sym = Sym("•", "*");
+pub const PROMPT_CHAR: Sym = Sym("❯", ">");
+pub const BRANCH: Sym = Sym("├", "|");
+pub const BRANCH_END: Sym = Sym("└", "`");
+pub const BOLT: Sym = Sym("⚡", "*");
+pub const BANG: Sym = Sym("!", "!");
+pub const HOOK_STOP: Sym = Sym("■", "!");
+
+fn rule_char() -> &'static str {
+    if ascii_enabled() {
+        "-"
+    } else {
+        "─"
+    }
+}
 
 /// Left margin every block shares, so the transcript has a consistent gutter.
 pub const PAD: &str = "  ";
@@ -44,23 +148,67 @@ pub fn content_width() -> usize {
 /// A muted full-width horizontal rule, indented by `PAD`.
 pub fn rule() -> String {
     let dashes = cols().saturating_sub(PAD.len());
-    format!("{PAD}{MUTED}{}{RESET}", "─".repeat(dashes))
+    format!("{PAD}{MUTED}{}{RESET}", rule_char().repeat(dashes))
 }
+
+/// 256-color ramp used by the fading turn headers (and the banner logo):
+/// bright cyan → teal → dark gray.
+pub(crate) const FADE_RAMP: [u8; 12] = [51, 45, 39, 38, 37, 31, 30, 24, 23, 237, 235, 234];
 
 /// A turn header: an accent label followed by a short rule (~20% of the width)
 /// that fades from bright cyan to dark, e.g. `response ──────╴`. The fade is
 /// done per-character with 256-color codes so it reads as a soft taper rather
 /// than a hard-edged bar. No bottom or side borders — just this top accent.
 pub fn fade_header(label: &str) -> String {
-    // 256-color ramp: bright cyan → teal → dark gray (fades toward a dark bg).
-    const RAMP: [u8; 12] = [51, 45, 39, 38, 37, 31, 30, 24, 23, 237, 235, 234];
     let len = (cols() / 5).clamp(6, 30);
-    let last = RAMP.len() - 1;
+    if !colors_enabled() {
+        return format!("{PAD}{label} {}", rule_char().repeat(len));
+    }
+    let last = FADE_RAMP.len() - 1;
     let denom = len.saturating_sub(1).max(1);
     let mut fade = String::new();
     for i in 0..len {
         let idx = ((i * last) / denom).min(last);
-        fade.push_str(&format!("\x1b[38;5;{}m─", RAMP[idx]));
+        fade.push_str(&format!("\x1b[38;5;{}m{}", FADE_RAMP[idx], rule_char()));
     }
     format!("{PAD}{ACCENT}{BOLD}{label}{RESET} {fade}{RESET}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolve_color_mode_precedence() {
+        use ColorMode::*;
+        // Always wins over everything, including NO_COLOR and non-tty.
+        assert!(resolve_color_mode(Always, true, true, false));
+        // Never wins over everything.
+        assert!(!resolve_color_mode(Never, false, false, true));
+        // Auto: on only for a tty without NO_COLOR / TERM=dumb.
+        assert!(resolve_color_mode(Auto, false, false, true));
+        assert!(!resolve_color_mode(Auto, true, false, true)); // NO_COLOR set
+        assert!(!resolve_color_mode(Auto, false, true, true)); // TERM=dumb
+        assert!(!resolve_color_mode(Auto, false, false, false)); // piped
+    }
+
+    #[test]
+    fn style_and_sym_render_by_switch() {
+        // Tests share one process; exercise both switch states in a single
+        // serialized test and restore the defaults afterwards.
+        COLORS_ENABLED.store(true, Ordering::Relaxed);
+        ASCII_SYMBOLS.store(false, Ordering::Relaxed);
+        assert_eq!(format!("{ACCENT}"), "\x1b[96m");
+        assert_eq!(format!("{OK}"), "✓");
+
+        COLORS_ENABLED.store(false, Ordering::Relaxed);
+        ASCII_SYMBOLS.store(true, Ordering::Relaxed);
+        assert_eq!(format!("{ACCENT}"), "");
+        assert_eq!(format!("{OK}"), "+");
+        assert!(fade_header("you").contains("you"));
+        assert!(!fade_header("you").contains('\x1b'));
+
+        COLORS_ENABLED.store(true, Ordering::Relaxed);
+        ASCII_SYMBOLS.store(false, Ordering::Relaxed);
+    }
 }

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -145,6 +145,26 @@ pub fn content_width() -> usize {
     cols().saturating_sub(PAD.len() + 1).max(20)
 }
 
+/// Visible width of a string, ignoring ANSI escape sequences (`ESC [ … m`).
+/// Used anywhere layout must count columns of already-styled text — the
+/// input prompt and the streamed-answer word-wrapper both rely on it.
+pub fn visible_len(s: &str) -> usize {
+    let mut n = 0;
+    let mut in_esc = false;
+    for ch in s.chars() {
+        if in_esc {
+            if ch == 'm' {
+                in_esc = false;
+            }
+        } else if ch == '\x1b' {
+            in_esc = true;
+        } else {
+            n += 1;
+        }
+    }
+    n
+}
+
 /// A muted full-width horizontal rule, indented by `PAD`.
 pub fn rule() -> String {
     let dashes = cols().saturating_sub(PAD.len());

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -72,8 +72,6 @@ impl std::fmt::Display for Style {
 
 pub const RESET: Style = Style("\x1b[0m");
 pub const BOLD: Style = Style("\x1b[1m");
-// Used by the streamed-markdown state machine (visual-polish step 6).
-#[allow(dead_code)]
 pub const ITALIC: Style = Style("\x1b[3m");
 
 /// Accent — prompts, headers, the active step. Bright cyan.
@@ -107,9 +105,6 @@ pub const CHECK: Sym = Sym("✔", "+");
 pub const PENDING: Sym = Sym("○", "o");
 pub const SUB: Sym = Sym("↳", ">");
 pub const WARN_MARK: Sym = Sym("▲", "!");
-// Used by the streamed-markdown state machine for `- `/`* ` list items
-// (visual-polish step 6).
-#[allow(dead_code)]
 pub const BULLET: Sym = Sym("•", "*");
 pub const PROMPT_CHAR: Sym = Sym("❯", ">");
 pub const BRANCH: Sym = Sym("├", "|");
@@ -169,6 +164,22 @@ pub fn visible_len(s: &str) -> usize {
 pub fn rule() -> String {
     let dashes = cols().saturating_sub(PAD.len());
     format!("{PAD}{MUTED}{}{RESET}", rule_char().repeat(dashes))
+}
+
+/// A dim rule that frames a fenced code block. With a language it reads
+/// `── rust ─────`; the closing rule (empty language) is just dashes. No
+/// leading `PAD` — the renderer positions it directly under the answer gutter.
+pub fn code_fence_rule(lang: &str) -> String {
+    let target = content_width().min(48);
+    let rc = rule_char();
+    let lang = lang.trim();
+    if lang.is_empty() {
+        format!("{MUTED}{}{RESET}", rc.repeat(target))
+    } else {
+        let label = format!("{rc}{rc} {lang} ");
+        let remain = target.saturating_sub(visible_len(&label));
+        format!("{MUTED}{label}{}{RESET}", rc.repeat(remain))
+    }
 }
 
 /// 256-color ramp used by the fading turn headers (and the banner logo):

--- a/src/turn_trace.rs
+++ b/src/turn_trace.rs
@@ -113,7 +113,7 @@ impl TurnMetrics {
         if self.total_ms > 0 {
             parts.push(format!("total {:.1}s", self.total_ms as f64 / 1000.0));
         }
-        format!(" · {}", parts.join(" · "))
+        parts.join(" · ")
     }
 }
 


### PR DESCRIPTION
## Summary

The "signature look" visual-polish bundle for Small Harness — makes the TUI stand out in demos/screenshots while staying a plain-scrollback ANSI app (no alternate screen, no ratatui, no new dependencies). Landed as 7 self-contained, individually-green commits.

**Headline feature:** assistant answers are now styled **as they stream** — bold, italic, inline code, headings, and bullets, plus fenced code blocks framed with dim rules (`── rust ───`) around a verbatim, copy-paste-faithful region.

## What's in it

- **Streamed markdown styling** (`src/markdown.rs`) — a chunk-boundary-safe `MarkdownInline` state machine. Markers split across deltas (`*`+`*`) resolve correctly; conservative emphasis flanking leaves `snake_case` and `2 * 3` alone; unclosed markers reset at newline.
- **Colored diffs** (`src/diff_view.rs`) — green `+` / red `−` / cyan `@@` in approval previews and `/path diff`/pick.
- **Runtime theming** — `Style`/`Sym` wrappers add **`NO_COLOR`** support, a `display.color` (`auto`/`always`/`never`) knob, and `display.ascii` glyph fallbacks — retrofitted onto ~200 call sites without touching them (type change, not signature change).
- **ANSI-blind word wrap** — injected color/bold codes no longer skew wrap columns; a verbatim mode keeps code lines intact.
- **Banner** gets a gradient logo + version string; **status line** joins parts with one separator and highlights turn cost over \$0.50; **spacing** normalized so blocks own a leading (not trailing) blank.

## Rendered output (width 40)

```
  # Setup            → bold+cyan heading, '#' stripped
  Install **deps**   → bold
  `cargo build`      → cyan inline code
  - first step       → cyan • bullet
  ── rust ───────────────────────────
  fn main() {
      println!("hi");   ← indentation preserved verbatim
  }
  ────────────────────────────────────
```

## Testing

- **539 tests pass** (was 505 on main — 34 new), `clippy --all-targets -D warnings` clean, `fmt --check` clean — on every commit.
- New unit coverage: `resolve_color_mode` precedence, diff classification, footer joining, ANSI-width exclusion + verbatim wrap, 13 markdown state-machine cases (split markers, snake_case/math safety, fence enter/exit), and an end-to-end MarkdownInline→StreamWrap width guarantee.
- Step 6's output was eyeballed with escapes made visible (see above).

## Verification caveat

The sandbox this was built in has no TTY, so the **interactive spacing and fence framing in a real terminal** are the one thing not yet eyeballed live. Everything is unit-tested and the streaming pipeline was verified via captured output, but a quick `cargo run` with a local model — checking `/help`, a tool-heavy turn, and a markdown-rich response, plus `NO_COLOR=1` and `display.ascii` — is worth doing before merge.

## Config

New `display` keys (both optional, back-compatible defaults):
- `color`: `auto` (default) — off under `NO_COLOR`, `TERM=dumb`, or non-tty; `always`; `never`
- `ascii`: `false` (default) — ASCII fallbacks for `✓ ✗ ▸ •` and the braille spinner

🤖 Generated with [Claude Code](https://claude.com/claude-code)