### PR TITLE
perf(cache): keep the prompt-cache prefix stable and request/report the cache

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -317,7 +317,7 @@ where
     let mut total_cached: u32 = 0;
     let mut reported_cost_usd: Option<f64> = None;
     // Prefix identity is fixed for the turn (system message + model are stable
-    // across steps), so derive the cache-routing key once and reuse it.
+    // across steps), so derive OpenAI's cache-routing key once and reuse it.
     let cache_key = crate::openai::session_cache_key(backend, model, &messages);
     let mut transcript_rewritten = false;
     let mut natural_stop = false;

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -80,6 +80,9 @@ pub struct RunResult {
     pub messages: Vec<ChatMessage>,
     pub input_tokens: u32,
     pub output_tokens: u32,
+    /// Portion of `input_tokens` the provider served from its prompt cache
+    /// across this turn's steps (0 when the provider reports no cache details).
+    pub cached_input_tokens: u32,
     pub reported_cost_usd: Option<f64>,
     pub transcript_rewritten: bool,
     pub conversation_summary: Option<String>,
@@ -311,7 +314,11 @@ where
 
     let mut total_in: u32 = 0;
     let mut total_out: u32 = 0;
+    let mut total_cached: u32 = 0;
     let mut reported_cost_usd: Option<f64> = None;
+    // Prefix identity is fixed for the turn (system message + model are stable
+    // across steps), so derive the cache-routing key once and reuse it.
+    let cache_key = crate::openai::session_cache_key(backend, model, &messages);
     let mut transcript_rewritten = false;
     let mut natural_stop = false;
     let mut conversation_summary = guard
@@ -351,6 +358,7 @@ where
                 include_usage: true,
             }),
             max_tokens: None,
+            prompt_cache_key: cache_key.as_deref(),
             effort,
         };
 
@@ -418,6 +426,7 @@ where
             if let Some(usage) = &chunk.usage {
                 total_in += usage.prompt_tokens;
                 total_out += usage.completion_tokens;
+                total_cached += usage.cached_tokens();
                 if let Some(cost) = usage.cost {
                     step_reported_cost_usd = Some(cost);
                 }
@@ -1012,6 +1021,7 @@ where
         messages,
         input_tokens: total_in,
         output_tokens: total_out,
+        cached_input_tokens: total_cached,
         reported_cost_usd,
         transcript_rewritten,
         conversation_summary,

--- a/src/agent_eval.rs
+++ b/src/agent_eval.rs
@@ -648,6 +648,7 @@ mod tests {
                 messages: vec![],
                 input_tokens: 0,
                 output_tokens: 0,
+                cached_input_tokens: 0,
                 reported_cost_usd: None,
                 transcript_rewritten: false,
                 conversation_summary: None,

--- a/src/auto_loop.rs
+++ b/src/auto_loop.rs
@@ -493,6 +493,7 @@ pub(crate) async fn run_done_check(
             include_usage: false,
         }),
         max_tokens: Some(400),
+        prompt_cache_key: None,
         effort: None,
     };
     let mut raw = String::new();

--- a/src/codex_responses.rs
+++ b/src/codex_responses.rs
@@ -213,12 +213,17 @@ fn one_tool_chunk(
     }
 }
 
-fn usage_chunk(input: u32, output: u32) -> StreamChunk {
+fn usage_chunk(input: u32, output: u32, cached: u32) -> StreamChunk {
     StreamChunk {
         choices: Vec::new(),
         usage: Some(Usage {
             prompt_tokens: input,
             completion_tokens: output,
+            // The Responses API reports cache reuse under
+            // `input_tokens_details.cached_tokens`; surface it like the chat path.
+            prompt_tokens_details: (cached > 0).then_some(crate::openai::PromptTokensDetails {
+                cached_tokens: cached,
+            }),
             cost: None,
         }),
     }
@@ -372,8 +377,13 @@ where
                     .get("output_tokens")
                     .and_then(Value::as_u64)
                     .unwrap_or(0) as u32;
+                let cached = usage
+                    .get("input_tokens_details")
+                    .and_then(|d| d.get("cached_tokens"))
+                    .and_then(Value::as_u64)
+                    .unwrap_or(0) as u32;
                 if input > 0 || output > 0 {
-                    on_chunk(usage_chunk(input, output));
+                    on_chunk(usage_chunk(input, output, cached));
                 }
             }
             return Ok(true);
@@ -531,6 +541,7 @@ mod tests {
             stream: true,
             stream_options: None,
             max_tokens: None,
+            prompt_cache_key: None,
             effort: None,
         };
         let body = build_request_body(&req);
@@ -565,5 +576,51 @@ mod tests {
         let call = chunks[1].choices[0].delta.tool_calls.as_ref().unwrap()[0].clone();
         assert_eq!(call.id.as_deref(), Some("call_1"));
         assert_eq!(call.function.unwrap().name.as_deref(), Some("grep"));
+    }
+
+    #[test]
+    fn response_completed_surfaces_cached_prompt_tokens() {
+        let mut chunks = Vec::new();
+        let mut calls = BTreeMap::new();
+        let mut next_index = 0;
+        let done = handle_event(
+            json!({
+                "type": "response.completed",
+                "response": {"usage": {
+                    "input_tokens": 1200,
+                    "output_tokens": 87,
+                    "input_tokens_details": {"cached_tokens": 900}
+                }}
+            }),
+            &mut calls,
+            &mut next_index,
+            |c| chunks.push(c),
+        )
+        .unwrap();
+        assert!(done);
+        let usage = chunks[0].usage.as_ref().unwrap();
+        assert_eq!(usage.prompt_tokens, 1200);
+        assert_eq!(usage.completion_tokens, 87);
+        assert_eq!(usage.cached_tokens(), 900);
+    }
+
+    #[test]
+    fn response_completed_without_cache_details_reports_zero_cached() {
+        let mut chunks = Vec::new();
+        let mut calls = BTreeMap::new();
+        let mut next_index = 0;
+        handle_event(
+            json!({
+                "type": "response.completed",
+                "response": {"usage": {"input_tokens": 40, "output_tokens": 10}}
+            }),
+            &mut calls,
+            &mut next_index,
+            |c| chunks.push(c),
+        )
+        .unwrap();
+        let usage = chunks[0].usage.as_ref().unwrap();
+        assert_eq!(usage.cached_tokens(), 0);
+        assert!(usage.prompt_tokens_details.is_none());
     }
 }

--- a/src/commands/config_cmds.rs
+++ b/src/commands/config_cmds.rs
@@ -983,6 +983,7 @@ pub(super) async fn cmd_compare(args: &str, state: &AppState) -> Result<()> {
             include_usage: false,
         }),
         max_tokens: None,
+        prompt_cache_key: None,
         effort: None,
     };
     let mut out = std::io::stdout();

--- a/src/commands/context_cmds.rs
+++ b/src/commands/context_cmds.rs
@@ -89,6 +89,7 @@ pub(crate) async fn perform_reset(state: &mut AppState, dry_run: bool) -> Result
             include_usage: false,
         }),
         max_tokens: Some(1200),
+        prompt_cache_key: None,
         effort: None,
     };
     let mut draft = String::new();

--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -177,6 +177,7 @@ async fn probe_streaming(
             include_usage: true,
         }),
         max_tokens: Some(8),
+        prompt_cache_key: None,
         effort: None,
     };
     let mut chunks = 0usize;
@@ -262,6 +263,7 @@ async fn probe_tool_calls(
             include_usage: false,
         }),
         max_tokens: Some(128),
+        prompt_cache_key: None,
         effort: None,
     };
     let mut content = String::new();
@@ -583,6 +585,7 @@ async fn cmd_bench(args: &str, state: &AppState) -> Result<()> {
             include_usage: false,
         }),
         max_tokens: None,
+        prompt_cache_key: None,
         effort: state.active_effort,
     };
     let start = Instant::now();

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -535,6 +535,7 @@ async fn cmd_handoff(args: &str, state: &AppState) -> Result<()> {
             include_usage: false,
         }),
         max_tokens: Some(900),
+        prompt_cache_key: None,
         effort: None,
     };
     let mut draft = String::new();
@@ -822,6 +823,7 @@ async fn cmd_plan(args: &str, state: &mut AppState) -> Result<()> {
             include_usage: false,
         }),
         max_tokens: Some(1500),
+        prompt_cache_key: None,
         effort: state.active_effort,
     };
     let mut draft = String::new();
@@ -904,6 +906,7 @@ async fn cmd_plan_route(
             include_usage: true,
         }),
         max_tokens: Some(2400),
+        prompt_cache_key: None,
         effort: planner.effort,
     };
     let mut draft = String::new();

--- a/src/commands/route.rs
+++ b/src/commands/route.rs
@@ -417,6 +417,7 @@ async fn run_selector(state: &AppState, selector: &ModelRef, task: &str) -> Resu
             include_usage: true,
         }),
         max_tokens: Some(500),
+        prompt_cache_key: None,
         effort: selector.effort,
     };
     let mut text = String::new();

--- a/src/commands/ship.rs
+++ b/src/commands/ship.rs
@@ -1195,6 +1195,7 @@ async fn draft_ship_commit_message(
             include_usage: false,
         }),
         max_tokens: Some(500),
+        prompt_cache_key: None,
         effort: None,
     };
     let mut draft = String::new();

--- a/src/commands/workflow.rs
+++ b/src/commands/workflow.rs
@@ -43,6 +43,7 @@ async fn eval_once(
             include_usage: false,
         }),
         max_tokens: None,
+        prompt_cache_key: None,
         effort: None,
     };
     let mut out = String::new();
@@ -832,6 +833,7 @@ async fn run_prompt_content(content: &str, state: &mut AppState) -> Result<()> {
             include_usage: true,
         }),
         max_tokens: None,
+        prompt_cache_key: None,
         effort: state.active_effort,
     };
 

--- a/src/context_guard.rs
+++ b/src/context_guard.rs
@@ -535,6 +535,7 @@ pub async fn summarize_transcript(
             include_usage: false,
         }),
         max_tokens: None,
+        prompt_cache_key: None,
         effort: None,
     };
     let mut out = String::new();

--- a/src/context_guard.rs
+++ b/src/context_guard.rs
@@ -6,7 +6,7 @@ use std::path::{Path, PathBuf};
 
 use crate::backends::BackendDescriptor;
 use crate::budget::{
-    format_bytes, headroom_bytes, measure_prompt_budget, usage_ratio, PromptBudget,
+    estimate_tokens, format_bytes, headroom_bytes, measure_prompt_budget, usage_ratio, PromptBudget,
 };
 use crate::config::{AgentConfig, ContextConfig};
 use crate::openai::{stream_chat, ChatMessage, ChatRequest, StreamOptions, ToolDef};
@@ -771,10 +771,14 @@ pub async fn maybe_auto_compact(
     ctx: &mut CompactSessionContext<'_>,
     session_dir: &str,
     session_path: &mut PathBuf,
+    request_only_context_bytes: usize,
 ) -> Result<Option<CompactNotice>> {
     let guard = guard_config_from(ctx.config, ctx.model, ctx.is_local);
     let active_system_prompt = merge_system_prompt(ctx.system_prompt, ctx.conversation_summary);
-    let budget = measure_prompt_budget(&active_system_prompt, ctx.messages, ctx.tool_defs);
+    let budget = add_request_only_context_bytes(
+        measure_prompt_budget(&active_system_prompt, ctx.messages, ctx.tool_defs),
+        request_only_context_bytes,
+    );
 
     if !guard.auto_compact {
         if should_compact(
@@ -802,11 +806,23 @@ pub async fn maybe_auto_compact(
         return Ok(None);
     }
 
-    let result = compact_messages(ctx, None).await?;
+    let mut result = compact_messages(ctx, None).await?;
 
     if !result.compacted {
         return Ok(None);
     }
+
+    // `compact_messages` operates on the durable raw transcript. Correct its
+    // reported ratios for request-only context that is injected on the wire
+    // but intentionally never written into session history.
+    result.before_ratio = usage_ratio(&budget, guard.effective_limit_bytes);
+    let active_system_prompt =
+        merge_system_prompt(ctx.system_prompt, result.conversation_summary.as_deref());
+    let after_budget = add_request_only_context_bytes(
+        measure_prompt_budget(&active_system_prompt, ctx.messages, ctx.tool_defs),
+        request_only_context_bytes,
+    );
+    result.after_ratio = usage_ratio(&after_budget, guard.effective_limit_bytes);
 
     rewrite_session_transcript(session_dir, session_path, ctx.messages)?;
 
@@ -815,6 +831,23 @@ pub async fn maybe_auto_compact(
         conversation_summary: result.conversation_summary.clone(),
         transcript_rewritten: true,
     }))
+}
+
+fn add_request_only_context_bytes(
+    mut budget: PromptBudget,
+    request_only_context_bytes: usize,
+) -> PromptBudget {
+    budget.transcript_bytes = budget
+        .transcript_bytes
+        .saturating_add(request_only_context_bytes);
+    budget.total_bytes = budget
+        .total_bytes
+        .saturating_add(request_only_context_bytes);
+    budget.effective_total_bytes = budget
+        .effective_total_bytes
+        .saturating_add(request_only_context_bytes);
+    budget.estimated_tokens = estimate_tokens(budget.effective_total_bytes);
+    budget
 }
 
 pub async fn maybe_compact_messages(

--- a/src/openai.rs
+++ b/src/openai.rs
@@ -134,27 +134,26 @@ pub struct ChatRequest<'a> {
     pub stream_options: Option<StreamOptions>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub max_tokens: Option<u32>,
-    /// Stable per-session cache-routing hint for hosted providers (OpenAI
-    /// `prompt_cache_key`). Keeps a session's requests on the same cache so the
-    /// shared system+tools+history prefix stays warm across turns. Omitted for
-    /// local backends, which ignore it. See [`session_cache_key`].
-    #[serde(skip_serializing_if = "Option::is_none")]
+    /// Stable cache-routing hint for OpenAI Chat Completions. The request-body
+    /// builder deliberately omits it for every other backend because compatible
+    /// APIs use different routing fields (or enable prompt caching automatically).
+    #[serde(skip)]
     pub prompt_cache_key: Option<&'a str>,
     #[serde(skip)]
     pub effort: Option<EffortLevel>,
 }
 
-/// Derive a stable prompt-cache-routing key from the request's cacheable prefix
-/// (model + the position-0 system message, which the interactive loop keeps
-/// byte-identical across turns). Same session/config yields the same key every
-/// turn, so hosted providers co-locate the session and keep its prefix cached.
-/// Returns `None` for local backends, which do not use the hint.
+/// Derive OpenAI's stable prompt-cache-routing key from the request's cacheable
+/// prefix (model + the position-0 system message). Other hosted providers have
+/// different routing contracts: OpenRouter handles conversation stickiness
+/// itself, while Grok's cache is automatic. Sending OpenAI's field to those
+/// compatible APIs can make an otherwise valid request fail.
 pub fn session_cache_key(
     backend: &BackendDescriptor,
     model: &str,
     messages: &[ChatMessage],
 ) -> Option<String> {
-    if backend.is_local {
+    if !matches!(backend.name, BackendName::OpenAi) {
         return None;
     }
     use std::hash::{Hash, Hasher};
@@ -465,6 +464,13 @@ where
 
 fn request_body(backend: &BackendDescriptor, req: &ChatRequest<'_>) -> Result<Value> {
     let mut body = serde_json::to_value(req)?;
+    if matches!(backend.name, BackendName::OpenAi) {
+        if let Some(key) = req.prompt_cache_key {
+            body.as_object_mut()
+                .ok_or_else(|| anyhow!("chat request did not serialize to an object"))?
+                .insert("prompt_cache_key".into(), Value::String(key.into()));
+        }
+    }
     if let Some(effort) = req.effort {
         apply_effort_to_request(backend, &mut body, effort)?;
     }
@@ -880,7 +886,8 @@ mod tests {
             session_cache_key(&hosted, "gpt-4o", &a_plus),
         );
 
-        // Local backends opt out: no hint is emitted at all.
+        // Every non-OpenAI backend opts out: compatible APIs use different
+        // routing contracts and must not receive OpenAI-only request fields.
         let local = BackendDescriptor {
             name: BackendName::Ollama,
             base_url: "http://localhost:11434/v1".into(),
@@ -889,6 +896,14 @@ mod tests {
             openrouter: OpenRouterConfig::default(),
         };
         assert_eq!(session_cache_key(&local, "gpt-4o", &a), None);
+        let openrouter = BackendDescriptor {
+            name: BackendName::Openrouter,
+            base_url: "https://openrouter.ai/api/v1".into(),
+            api_key: "test".into(),
+            is_local: false,
+            openrouter: OpenRouterConfig::default(),
+        };
+        assert_eq!(session_cache_key(&openrouter, "gpt-4o", &a), None);
     }
 
     #[test]
@@ -911,16 +926,25 @@ mod tests {
         // see the field.
         let without = request_body(&backend, &base).unwrap();
         assert!(without.get("prompt_cache_key").is_none());
-        // Round-trips onto the wire verbatim when present.
-        let with = request_body(
-            &backend,
-            &ChatRequest {
-                prompt_cache_key: Some("sh-deadbeef"),
-                ..base
-            },
-        )
-        .unwrap();
+        // Round-trips onto the native OpenAI wire format when present.
+        let with_key = ChatRequest {
+            prompt_cache_key: Some("sh-deadbeef"),
+            ..base
+        };
+        let with = request_body(&backend, &with_key).unwrap();
         assert_eq!(with["prompt_cache_key"], "sh-deadbeef");
+
+        // Even an incorrectly populated request cannot leak the OpenAI-only
+        // field to a compatible backend.
+        let openrouter = BackendDescriptor {
+            name: BackendName::Openrouter,
+            base_url: "https://openrouter.ai/api/v1".into(),
+            api_key: "test".into(),
+            is_local: false,
+            openrouter: OpenRouterConfig::default(),
+        };
+        let compatible = request_body(&openrouter, &with_key).unwrap();
+        assert!(compatible.get("prompt_cache_key").is_none());
     }
 
     #[test]

--- a/src/openai.rs
+++ b/src/openai.rs
@@ -134,8 +134,36 @@ pub struct ChatRequest<'a> {
     pub stream_options: Option<StreamOptions>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub max_tokens: Option<u32>,
+    /// Stable per-session cache-routing hint for hosted providers (OpenAI
+    /// `prompt_cache_key`). Keeps a session's requests on the same cache so the
+    /// shared system+tools+history prefix stays warm across turns. Omitted for
+    /// local backends, which ignore it. See [`session_cache_key`].
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub prompt_cache_key: Option<&'a str>,
     #[serde(skip)]
     pub effort: Option<EffortLevel>,
+}
+
+/// Derive a stable prompt-cache-routing key from the request's cacheable prefix
+/// (model + the position-0 system message, which the interactive loop keeps
+/// byte-identical across turns). Same session/config yields the same key every
+/// turn, so hosted providers co-locate the session and keep its prefix cached.
+/// Returns `None` for local backends, which do not use the hint.
+pub fn session_cache_key(
+    backend: &BackendDescriptor,
+    model: &str,
+    messages: &[ChatMessage],
+) -> Option<String> {
+    if backend.is_local {
+        return None;
+    }
+    use std::hash::{Hash, Hasher};
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    model.hash(&mut hasher);
+    if let Some(ChatMessage::System { content }) = messages.first() {
+        content.hash(&mut hasher);
+    }
+    Some(format!("sh-{:016x}", hasher.finish()))
 }
 
 #[derive(Debug, Serialize)]
@@ -193,6 +221,28 @@ pub struct Usage {
     pub completion_tokens: u32,
     #[serde(default)]
     pub cost: Option<f64>,
+    /// Cached-prompt accounting, when the provider reports it. OpenAI and
+    /// OpenRouter nest the cache hit here as `prompt_tokens_details.cached_tokens`
+    /// (a subset of `prompt_tokens`); local backends omit it.
+    #[serde(default)]
+    pub prompt_tokens_details: Option<PromptTokensDetails>,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct PromptTokensDetails {
+    #[serde(default)]
+    pub cached_tokens: u32,
+}
+
+impl Usage {
+    /// Prompt tokens served from the provider's prompt cache this call, or 0
+    /// when the provider reports no cache details.
+    pub fn cached_tokens(&self) -> u32 {
+        self.prompt_tokens_details
+            .as_ref()
+            .map(|d| d.cached_tokens)
+            .unwrap_or(0)
+    }
 }
 
 pub fn build_http_client() -> reqwest::Client {
@@ -775,6 +825,7 @@ mod tests {
             stream: true,
             stream_options: None,
             max_tokens: None,
+            prompt_cache_key: None,
             effort: None,
         };
 
@@ -784,6 +835,92 @@ mod tests {
         assert_eq!(plugin["analysis_models"][0], "~google/gemini-flash-latest");
         assert_eq!(plugin["model"], "~anthropic/claude-opus-latest");
         assert_eq!(plugin["max_tool_calls"], 4);
+    }
+
+    fn hosted_backend() -> BackendDescriptor {
+        BackendDescriptor {
+            name: BackendName::OpenAi,
+            base_url: "https://api.openai.com/v1".into(),
+            api_key: "test".into(),
+            is_local: false,
+            openrouter: OpenRouterConfig::default(),
+        }
+    }
+
+    #[test]
+    fn session_cache_key_is_stable_and_prefix_scoped() {
+        let hosted = hosted_backend();
+        let sys = |t: &str| vec![ChatMessage::System { content: t.into() }];
+        let a = sys("stable system prompt");
+
+        // Same model + same system prefix => identical key across turns. This is
+        // the whole point: a session keeps routing to the same warm cache shard.
+        assert_eq!(
+            session_cache_key(&hosted, "gpt-4o", &a),
+            session_cache_key(&hosted, "gpt-4o", &a),
+        );
+        // A different model must not share a cache key.
+        assert_ne!(
+            session_cache_key(&hosted, "gpt-4o", &a),
+            session_cache_key(&hosted, "gpt-4o-mini", &a),
+        );
+        // A different stable prefix (system prompt) must not share a cache key.
+        assert_ne!(
+            session_cache_key(&hosted, "gpt-4o", &a),
+            session_cache_key(&hosted, "gpt-4o", &sys("a different system prompt")),
+        );
+        // Appending volatile turns below the prefix must NOT change the key,
+        // otherwise every turn would route to a cold shard.
+        let mut a_plus = a.clone();
+        a_plus.push(ChatMessage::User {
+            content: "turn two".into(),
+        });
+        assert_eq!(
+            session_cache_key(&hosted, "gpt-4o", &a),
+            session_cache_key(&hosted, "gpt-4o", &a_plus),
+        );
+
+        // Local backends opt out: no hint is emitted at all.
+        let local = BackendDescriptor {
+            name: BackendName::Ollama,
+            base_url: "http://localhost:11434/v1".into(),
+            api_key: String::new(),
+            is_local: true,
+            openrouter: OpenRouterConfig::default(),
+        };
+        assert_eq!(session_cache_key(&local, "gpt-4o", &a), None);
+    }
+
+    #[test]
+    fn prompt_cache_key_is_serialized_only_when_set() {
+        let backend = hosted_backend();
+        let messages = vec![ChatMessage::User {
+            content: "hi".into(),
+        }];
+        let base = ChatRequest {
+            model: "gpt-4o",
+            messages: &messages,
+            tools: None,
+            stream: true,
+            stream_options: None,
+            max_tokens: None,
+            prompt_cache_key: None,
+            effort: None,
+        };
+        // Omitted when None (serde skip), so backends that don't support it never
+        // see the field.
+        let without = request_body(&backend, &base).unwrap();
+        assert!(without.get("prompt_cache_key").is_none());
+        // Round-trips onto the wire verbatim when present.
+        let with = request_body(
+            &backend,
+            &ChatRequest {
+                prompt_cache_key: Some("sh-deadbeef"),
+                ..base
+            },
+        )
+        .unwrap();
+        assert_eq!(with["prompt_cache_key"], "sh-deadbeef");
     }
 
     #[test]
@@ -805,6 +942,7 @@ mod tests {
             stream: true,
             stream_options: None,
             max_tokens: None,
+            prompt_cache_key: None,
             effort: Some(EffortLevel::Max),
         };
 
@@ -832,6 +970,7 @@ mod tests {
             stream: true,
             stream_options: None,
             max_tokens: None,
+            prompt_cache_key: None,
             effort: Some(EffortLevel::High),
         };
 
@@ -865,6 +1004,7 @@ mod tests {
             stream: true,
             stream_options: None,
             max_tokens: None,
+            prompt_cache_key: None,
             effort: None,
         };
 
@@ -936,6 +1076,7 @@ mod tests {
             stream: true,
             stream_options: None,
             max_tokens: None,
+            prompt_cache_key: None,
             effort: None,
         };
         let mut name = String::new();

--- a/src/project_memory.rs
+++ b/src/project_memory.rs
@@ -658,22 +658,47 @@ pub fn maybe_project_context(
     Some(map.content)
 }
 
+/// Header the prompt-focused repo map is injected under, whether it lives in
+/// the system prompt (one-shot/eval callers) or is folded below the cache
+/// boundary into the current user turn (the interactive loop).
+pub const PROJECT_CONTEXT_HEADER: &str = "Local project memory context:";
+
+fn append_project_prompt(out: &mut String, workspace_root: &str) {
+    if let Some(project_prompt) = load_project_prompt(workspace_root) {
+        out.push_str("\n\nProject-specific guidance (.small-harness/prompt.md):\n");
+        out.push_str(&project_prompt);
+    }
+}
+
+/// System prompt that stays byte-identical across turns within a session:
+/// base prompt plus the static `.small-harness/prompt.md` guidance.
+///
+/// It deliberately omits the prompt-focused repo map ([`maybe_project_context`]),
+/// which is re-ranked against every user message and so changes each turn.
+/// Keeping that volatile block out of the position-0 system message lets the
+/// cached prefix (system + tools + prior turns) survive across turns for both
+/// hosted prompt caching and local KV/prefix reuse. The interactive loop folds
+/// the map into the current user turn instead, below the cache boundary.
+pub fn render_stable_system_prompt(config: &AgentConfig, tools: &[String]) -> String {
+    let mut out = config.render_system_prompt_for_tools(tools);
+    append_project_prompt(&mut out, &config.workspace_root);
+    out
+}
+
 pub fn render_system_prompt_with_memory(
     config: &AgentConfig,
     backend: &BackendDescriptor,
     tools: &[String],
     prompt: &str,
 ) -> String {
-    let base = config.render_system_prompt_for_tools(tools);
-    let mut out = base;
+    let mut out = config.render_system_prompt_for_tools(tools);
     if let Some(context) = maybe_project_context(config, backend, prompt) {
-        out.push_str("\n\nLocal project memory context:\n");
+        out.push_str("\n\n");
+        out.push_str(PROJECT_CONTEXT_HEADER);
+        out.push('\n');
         out.push_str(&context);
     }
-    if let Some(project_prompt) = load_project_prompt(&config.workspace_root) {
-        out.push_str("\n\nProject-specific guidance (.small-harness/prompt.md):\n");
-        out.push_str(&project_prompt);
-    }
+    append_project_prompt(&mut out, &config.workspace_root);
     out
 }
 
@@ -1434,6 +1459,49 @@ mod tests {
             &cloud_backend(),
             "map this repo"
         ));
+    }
+
+    #[test]
+    fn stable_system_prompt_excludes_prompt_focused_map() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(dir.path().join("parser.rs"), "pub fn parse_tokens() {}\n").unwrap();
+        fs::write(dir.path().join("render.rs"), "pub fn render_frame() {}\n").unwrap();
+        let config = config_for(dir.path());
+        build_project_index(&config).unwrap();
+        let backend = local_backend();
+        let tools = vec!["file_read".to_string()];
+
+        // The focused map exists and is a function of the current user prompt.
+        let ctx =
+            maybe_project_context(&config, &backend, "how does parse_tokens read code").unwrap();
+        assert!(ctx.contains("Focused map for"));
+
+        // One-shot callers still embed the map, so their prompt varies per turn
+        // — exactly what makes it unfit for the cache prefix.
+        let full_a = render_system_prompt_with_memory(
+            &config,
+            &backend,
+            &tools,
+            "how does parse_tokens read code",
+        );
+        let full_b = render_system_prompt_with_memory(
+            &config,
+            &backend,
+            &tools,
+            "explain render_frame in this code",
+        );
+        assert!(full_a.contains(PROJECT_CONTEXT_HEADER));
+        assert_ne!(
+            full_a, full_b,
+            "system prompt with the map embedded changes with the user prompt"
+        );
+
+        // The stable prefix carries neither the header nor any focused map, and
+        // is identical regardless of the turn's prompt.
+        let stable = render_stable_system_prompt(&config, &tools);
+        assert!(!stable.contains(PROJECT_CONTEXT_HEADER));
+        assert!(!stable.contains("Focused map for"));
+        assert_eq!(stable, render_stable_system_prompt(&config, &tools));
     }
 
     #[test]

--- a/src/session_turn.rs
+++ b/src/session_turn.rs
@@ -399,13 +399,41 @@ fn fold_project_context_into_last_user(messages: &mut [ChatMessage], context: &s
     }
 }
 
+fn request_messages_with_project_context(
+    messages: &[ChatMessage],
+    context: Option<&str>,
+) -> Vec<ChatMessage> {
+    let mut request_messages = messages.to_vec();
+    if let Some(context) = context {
+        fold_project_context_into_last_user(&mut request_messages, context);
+    }
+    request_messages
+}
+
+fn restore_last_user_message(messages: &mut [ChatMessage], raw_user_message: &ChatMessage) {
+    let ChatMessage::User {
+        content: raw_content,
+    } = raw_user_message
+    else {
+        return;
+    };
+    if let Some(ChatMessage::User { content }) = messages
+        .iter_mut()
+        .rev()
+        .find(|message| matches!(message, ChatMessage::User { .. }))
+    {
+        *content = raw_content.clone();
+    }
+}
+
 fn maybe_print_context_pressure(
     state: &AppState,
     system_prompt: &str,
+    request_messages: &[ChatMessage],
     tool_defs: &[crate::openai::ToolDef],
 ) {
     let guard = guard_config_from(&state.config, &state.model, state.backend.is_local);
-    let budget = measure_prompt_budget(system_prompt, &state.messages, tool_defs);
+    let budget = measure_prompt_budget(system_prompt, request_messages, tool_defs);
     let ratio = usage_ratio(&budget, guard.effective_limit_bytes);
     let threshold = guard.compact_threshold * 0.7;
     if ratio < threshold {
@@ -524,12 +552,20 @@ pub async fn run_user_turn(state: &mut AppState, opts: TurnOptions) -> Result<Tu
     // closing after the agent future returns.
     drop(tool_runtime);
     let tool_defs = crate::agent::to_openai_tools(&tools);
-    maybe_print_context_pressure(state, &system_prompt, &tool_defs);
+    let request_messages =
+        request_messages_with_project_context(&state.messages, project_context.as_deref());
+    maybe_print_context_pressure(state, &system_prompt, &request_messages, &tool_defs);
 
     let compact_guard = guard_config_from(&state.config, &state.model, state.backend.is_local);
     let active_compact_prompt =
         merge_system_prompt(&base_system_prompt, state.conversation_summary.as_deref());
-    let compact_budget = measure_prompt_budget(&active_compact_prompt, &state.messages, &tool_defs);
+    let compact_budget =
+        measure_prompt_budget(&active_compact_prompt, &request_messages, &tool_defs);
+    let raw_compact_budget =
+        measure_prompt_budget(&active_compact_prompt, &state.messages, &tool_defs);
+    let request_only_context_bytes = compact_budget
+        .effective_total_bytes
+        .saturating_sub(raw_compact_budget.effective_total_bytes);
     let auto_compact_due = compact_guard.auto_compact
         && should_compact(
             &compact_budget,
@@ -577,6 +613,7 @@ pub async fn run_user_turn(state: &mut AppState, opts: TurnOptions) -> Result<Tu
             &mut compact_ctx,
             &state.session_dir,
             &mut state.session_path,
+            request_only_context_bytes,
         )
         .await?
         {
@@ -666,10 +703,8 @@ pub async fn run_user_turn(state: &mut AppState, opts: TurnOptions) -> Result<Tu
         }
     }
 
-    let mut initial = state.messages.clone();
-    if let Some(context) = project_context.as_deref() {
-        fold_project_context_into_last_user(&mut initial, context);
-    }
+    let initial =
+        request_messages_with_project_context(&state.messages, project_context.as_deref());
     let max_steps = state.config.max_steps;
     let model = state.model.clone();
     let active_effort = state.active_effort;
@@ -798,7 +833,12 @@ pub async fn run_user_turn(state: &mut AppState, opts: TurnOptions) -> Result<Tu
     }
     state.renderer.end_turn();
 
-    let res = result?;
+    let mut res = result?;
+    if project_context.is_some() {
+        // The model saw the request-only repo map, but session state and any
+        // transcript rewrite must retain exactly what the user submitted.
+        restore_last_user_message(&mut res.messages, &user_msg);
+    }
     let mut metrics = res.metrics.clone();
     if !opts.yolo_approve {
         metrics.approval_ms = tracing_approval.approval_ms.get();
@@ -1201,7 +1241,7 @@ mod cost_tests {
     fn footer_has_no_doubled_or_leading_separators_when_parts_empty() {
         let metrics = TurnMetrics::default();
         let footer = format_footer(
-            1200, 87, 0, None, true, 0.0, false, None, &metrics, "", "", "",
+            1200, 87, 0, None, true, 0.0, false, None, &metrics, "", "", "", "",
         );
         // Only the two always-present parts (tokens in/out) should appear,
         // joined by exactly one " · ", with no trailing/leading separator.
@@ -1249,19 +1289,7 @@ mod cost_tests {
     fn footer_ends_with_model_without_exposing_endpoint() {
         let metrics = TurnMetrics::default();
         let footer = format_footer(
-            100,
-            50,
-            0,
-            None,
-            true,
-            0.0,
-            false,
-            None,
-            &metrics,
-            "",
-            "",
-            "",
-            "grok-4.5",
+            100, 50, 0, None, true, 0.0, false, None, &metrics, "", "", "", "grok-4.5",
         );
         assert!(footer.contains("100 in · 50 out · grok-4.5"));
         assert!(!footer.contains("https://"));
@@ -1296,12 +1324,12 @@ mod cost_tests {
         let metrics = TurnMetrics::default();
         // Provider reported a cache hit: surface it between out and cost.
         let hit = format_footer(
-            1200, 87, 900, None, true, 0.0, false, None, &metrics, "", "", "",
+            1200, 87, 900, None, true, 0.0, false, None, &metrics, "", "", "", "",
         );
         assert!(hit.contains("1.2k in · 87 out · 900 cached"));
         // No cache hit reported: no "cached" part at all.
         let miss = format_footer(
-            1200, 87, 0, None, true, 0.0, false, None, &metrics, "", "", "",
+            1200, 87, 0, None, true, 0.0, false, None, &metrics, "", "", "", "",
         );
         assert!(!miss.contains("cached"));
     }
@@ -1433,6 +1461,44 @@ mod cost_tests {
             other => panic!("expected leading context text part, got {other:?}"),
         }
         assert!(matches!(parts[2], UserContentPart::ImageUrl { .. }));
+    }
+
+    #[test]
+    fn request_only_project_context_is_counted_in_prompt_budget() {
+        let messages = vec![
+            ChatMessage::System {
+                content: "stable system".into(),
+            },
+            ChatMessage::User {
+                content: "question".into(),
+            },
+        ];
+        let raw = measure_prompt_budget("stable system", &messages, &[]);
+        let request = request_messages_with_project_context(&messages, Some("repo map body"));
+        let augmented = measure_prompt_budget("stable system", &request, &[]);
+        assert!(augmented.effective_total_bytes > raw.effective_total_bytes);
+        assert_eq!(messages[1].user_text().unwrap(), "question");
+    }
+
+    #[test]
+    fn request_only_project_context_is_removed_before_persisting() {
+        let raw = ChatMessage::User {
+            content: "question".into(),
+        };
+        let mut request = vec![
+            ChatMessage::System {
+                content: "stable system".into(),
+            },
+            raw.clone(),
+        ];
+        fold_project_context_into_last_user(&mut request, "repo map body");
+        assert!(request[1]
+            .user_text()
+            .unwrap()
+            .contains(PROJECT_CONTEXT_HEADER));
+
+        restore_last_user_message(&mut request, &raw);
+        assert_eq!(request[1].user_text().unwrap(), "question");
     }
 
     #[test]

--- a/src/session_turn.rs
+++ b/src/session_turn.rs
@@ -180,6 +180,7 @@ fn format_effort_suffix(effort: Option<EffortLevel>) -> String {
 fn format_footer(
     input_tokens: u32,
     output_tokens: u32,
+    cached_input_tokens: u32,
     turn_cost: Option<f64>,
     backend_is_local: bool,
     session_usd: f64,
@@ -195,6 +196,11 @@ fn format_footer(
         format!("{} in", format_tokens(input_tokens)),
         format!("{} out", format_tokens(output_tokens)),
     ];
+    // Only surface cache reuse when the provider reported it, so local backends
+    // (which never report cached tokens) don't get a misleading "0 cached".
+    if cached_input_tokens > 0 {
+        parts.push(format!("{} cached", format_tokens(cached_input_tokens)));
+    }
     let cost = format_cost_suffix(
         turn_cost,
         backend_is_local,
@@ -953,6 +959,7 @@ pub async fn run_user_turn(state: &mut AppState, opts: TurnOptions) -> Result<Tu
         format_footer(
             res.input_tokens,
             res.output_tokens,
+            res.cached_input_tokens,
             turn_cost,
             state.config.backend.is_local(),
             state.session_usd,
@@ -1194,7 +1201,7 @@ mod cost_tests {
     fn footer_has_no_doubled_or_leading_separators_when_parts_empty() {
         let metrics = TurnMetrics::default();
         let footer = format_footer(
-            1200, 87, None, true, 0.0, false, None, &metrics, "", "", "", "",
+            1200, 87, 0, None, true, 0.0, false, None, &metrics, "", "", "",
         );
         // Only the two always-present parts (tokens in/out) should appear,
         // joined by exactly one " · ", with no trailing/leading separator.
@@ -1219,6 +1226,7 @@ mod cost_tests {
         let footer = format_footer(
             500,
             120,
+            0,
             Some(0.01),
             false,
             0.01,
@@ -1241,7 +1249,19 @@ mod cost_tests {
     fn footer_ends_with_model_without_exposing_endpoint() {
         let metrics = TurnMetrics::default();
         let footer = format_footer(
-            100, 50, None, true, 0.0, false, None, &metrics, "", "", "", "grok-4.5",
+            100,
+            50,
+            0,
+            None,
+            true,
+            0.0,
+            false,
+            None,
+            &metrics,
+            "",
+            "",
+            "",
+            "grok-4.5",
         );
         assert!(footer.contains("100 in · 50 out · grok-4.5"));
         assert!(!footer.contains("https://"));
@@ -1254,6 +1274,7 @@ mod cost_tests {
         let footer = format_footer(
             100,
             50,
+            0,
             None,
             true,
             0.0,
@@ -1268,6 +1289,21 @@ mod cost_tests {
         assert!(!footer.contains('$'));
         assert!(footer.contains("qwen2.5:7b"));
         assert!(!footer.contains("http://"));
+    }
+
+    #[test]
+    fn footer_shows_cached_tokens_only_when_present() {
+        let metrics = TurnMetrics::default();
+        // Provider reported a cache hit: surface it between out and cost.
+        let hit = format_footer(
+            1200, 87, 900, None, true, 0.0, false, None, &metrics, "", "", "",
+        );
+        assert!(hit.contains("1.2k in · 87 out · 900 cached"));
+        // No cache hit reported: no "cached" part at all.
+        let miss = format_footer(
+            1200, 87, 0, None, true, 0.0, false, None, &metrics, "", "", "",
+        );
+        assert!(!miss.contains("cached"));
     }
 
     #[test]

--- a/src/session_turn.rs
+++ b/src/session_turn.rs
@@ -22,7 +22,10 @@ use crate::hooks::{
 use crate::loader::Loader;
 use crate::model_system::EffortLevel;
 use crate::openai::{ChatMessage, ImageUrl, UserContent, UserContentPart};
-use crate::project_memory::{refresh_project_memory_after_write, render_system_prompt_with_memory};
+use crate::project_memory::{
+    maybe_project_context, refresh_project_memory_after_write, render_stable_system_prompt,
+    PROJECT_CONTEXT_HEADER,
+};
 use crate::session::save_message;
 use crate::shipcheck::{append_ship_context, collect_shipcheck};
 use crate::test_integration::{
@@ -369,6 +372,27 @@ pub(crate) fn system_prompt_with_hook_context(
     system_prompt
 }
 
+/// Fold the prompt-focused project context into the final user message of a
+/// request so it rides below the stable system/tools/history cache prefix
+/// instead of mutating the position-0 system message every turn. Mutates only
+/// the request copy; durable history keeps the user's raw prompt.
+fn fold_project_context_into_last_user(messages: &mut [ChatMessage], context: &str) {
+    for msg in messages.iter_mut().rev() {
+        if let ChatMessage::User { content } = msg {
+            let block = format!("{PROJECT_CONTEXT_HEADER}\n{context}\n\n");
+            match content {
+                UserContent::Text(text) => {
+                    *content = UserContent::Text(format!("{block}{text}"));
+                }
+                UserContent::Parts(parts) => {
+                    parts.insert(0, UserContentPart::Text { text: block });
+                }
+            }
+            return;
+        }
+    }
+}
+
 fn maybe_print_context_pressure(
     state: &AppState,
     system_prompt: &str,
@@ -428,16 +452,16 @@ pub async fn run_user_turn(state: &mut AppState, opts: TurnOptions) -> Result<Tu
     let trimmed = user_prompt.as_str();
 
     let active_tool_names = select_tool_names(&state.config, trimmed);
+    // The system message is the cache prefix; keep it prompt-independent. The
+    // prompt-focused repo map is computed here but folded into the current user
+    // turn below the cache boundary (see `initial` assembly), not the system
+    // prompt, so the cached prefix survives across turns.
     let raw_base_system_prompt = append_ship_context(
-        &render_system_prompt_with_memory(
-            &state.config,
-            &state.backend,
-            &active_tool_names,
-            trimmed,
-        ),
+        &render_stable_system_prompt(&state.config, &active_tool_names),
         &state.config,
         state.tests_ran_this_session,
     );
+    let project_context = maybe_project_context(&state.config, &state.backend, trimmed);
     let mut hook_prompt_contexts = Vec::new();
     hook_prompt_contexts.extend(state.session_hook_contexts.clone());
     hook_prompt_contexts.append(&mut state.pending_hook_contexts);
@@ -636,7 +660,10 @@ pub async fn run_user_turn(state: &mut AppState, opts: TurnOptions) -> Result<Tu
         }
     }
 
-    let initial = state.messages.clone();
+    let mut initial = state.messages.clone();
+    if let Some(context) = project_context.as_deref() {
+        fold_project_context_into_last_user(&mut initial, context);
+    }
     let max_steps = state.config.max_steps;
     let model = state.model.clone();
     let active_effort = state.active_effort;
@@ -1303,6 +1330,85 @@ mod cost_tests {
         assert!(merged.contains("(redacted)"));
         assert!(merged.contains("[truncated]"));
         assert!(merged.len() < 10_000);
+    }
+
+    #[test]
+    fn project_context_folds_into_last_user_not_system() {
+        let mut messages = vec![
+            ChatMessage::System {
+                content: "STABLE SYSTEM".into(),
+            },
+            ChatMessage::User {
+                content: UserContent::Text("first question".into()),
+            },
+            ChatMessage::Assistant {
+                content: Some("answer".into()),
+                tool_calls: vec![],
+            },
+            ChatMessage::User {
+                content: UserContent::Text("how does the parser work".into()),
+            },
+        ];
+        fold_project_context_into_last_user(&mut messages, "Focused map for `parser`:\n- src/x.rs");
+
+        // Cache prefix (system + earlier turns) must be untouched so it stays
+        // byte-identical across turns.
+        match &messages[0] {
+            ChatMessage::System { content } => assert_eq!(content, "STABLE SYSTEM"),
+            other => panic!("expected system at position 0, got {other:?}"),
+        }
+        assert_eq!(messages[1].user_text().unwrap(), "first question");
+
+        // The volatile map rides below the boundary, on the current user turn.
+        let last = messages[3].user_text().unwrap();
+        assert_eq!(
+            last,
+            "Local project memory context:\nFocused map for `parser`:\n- src/x.rs\n\nhow does the parser work"
+        );
+    }
+
+    #[test]
+    fn project_context_folds_ahead_of_image_parts() {
+        let mut messages = vec![ChatMessage::User {
+            content: UserContent::Parts(vec![
+                UserContentPart::Text {
+                    text: "describe this".into(),
+                },
+                UserContentPart::ImageUrl {
+                    image_url: ImageUrl {
+                        url: "data:image/png;base64,AAAA".into(),
+                    },
+                },
+            ]),
+        }];
+        fold_project_context_into_last_user(&mut messages, "MAP BODY");
+
+        let ChatMessage::User {
+            content: UserContent::Parts(parts),
+        } = &messages[0]
+        else {
+            panic!("expected multi-part user message");
+        };
+        assert_eq!(parts.len(), 3);
+        match &parts[0] {
+            UserContentPart::Text { text } => {
+                assert_eq!(text, "Local project memory context:\nMAP BODY\n\n");
+            }
+            other => panic!("expected leading context text part, got {other:?}"),
+        }
+        assert!(matches!(parts[2], UserContentPart::ImageUrl { .. }));
+    }
+
+    #[test]
+    fn folding_project_context_without_user_message_is_a_noop() {
+        let mut messages = vec![ChatMessage::System {
+            content: "sys".into(),
+        }];
+        fold_project_context_into_last_user(&mut messages, "map");
+        match &messages[0] {
+            ChatMessage::System { content } => assert_eq!(content, "sys"),
+            other => panic!("unexpected mutation: {other:?}"),
+        }
     }
 
     #[test]

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -452,6 +452,7 @@ async fn probe_setup_backend(config: &AgentConfig) {
         stream: false,
         stream_options: None,
         max_tokens: Some(4),
+        prompt_cache_key: None,
         effort: None,
     };
     match with_probe_timeout(chat_oneshot(&http, &backend_desc, &req)).await {

--- a/src/warmup.rs
+++ b/src/warmup.rs
@@ -29,6 +29,7 @@ pub async fn warmup(
         stream: false,
         stream_options: None,
         max_tokens: Some(1),
+        prompt_cache_key: None,
         effort,
     };
     chat_oneshot(http, backend, &req).await?;

--- a/src/warmup.rs
+++ b/src/warmup.rs
@@ -22,6 +22,7 @@ pub async fn warmup(
             content: "ok".into(),
         },
     ];
+    let cache_key = crate::openai::session_cache_key(backend, model, &messages);
     let req = ChatRequest {
         model,
         messages: &messages,
@@ -29,7 +30,9 @@ pub async fn warmup(
         stream: false,
         stream_options: None,
         max_tokens: Some(1),
-        prompt_cache_key: None,
+        // Use the same routing key as the real turn; otherwise a successful
+        // warmup may populate a different OpenAI cache shard.
+        prompt_cache_key: cache_key.as_deref(),
         effort,
     };
     chat_oneshot(http, backend, &req).await?;


### PR DESCRIPTION
The interactive loop rebuilt the position-0 system message every turn to embed a prompt-ranked repo map (`Focused map for <user prompt>`), whose content changes with each user prompt. Since prompt caching — OpenAI's hosted auto-cache and local llama.cpp/Ollama/vLLM KV reuse alike — matches on the longest shared token *prefix*, a system message that changes every turn invalidated the entire cached prefix (system + tools + prior turns) on every repo-related turn. The harness even re-runs `warmup` whenever the system-prompt fingerprint changes, so the churn was already costing real requests.

**Fix, two parts:**

1. Keep the prefix stable. `run_user_turn` now builds msg[0] from a new `render_stable_system_prompt` (base prompt + static `.small-harness/prompt.md` only, no focused map), and folds the prompt-focused map into the *current user message* (below the cache boundary) in the request copy only — so the map still reaches the model for the turn it was built for, durable history keeps the raw prompt, and the cached prefix survives across turns. One-shot/eval/status/compact callers are unchanged.

2. Actually use and report the cache. Send a stable `prompt_cache_key` (derived from model + the cacheable system prefix) on hosted requests so a session co-locates on one warm cache shard; omitted for local backends. Read back `prompt_tokens_details.cached_tokens`, aggregate it into `RunResult`, and show `<n> cached` in the per-turn footer when the provider reports a hit — for both the chat-completions and Codex Responses paths.

Tests: prefix stability (full prompt varies by input while the stable prompt carries no focused map), context folds into the last user message not the system prefix, `session_cache_key` stability/scoping, `prompt_cache_key` wire serialization, footer cached-token rendering, and Codex `response.completed` cached-token parsing. `cargo fmt`/`clippy -D warnings` clean.
