### PR TITLE
fix: reset cursor to column 0 after raw-mode sub-prompts

### DIFF
--- a/src/commands/config_cmds.rs
+++ b/src/commands/config_cmds.rs
@@ -510,8 +510,12 @@ pub(super) async fn cmd_backend(args: &str, state: &mut AppState) -> Result<()> 
         for (i, b) in BackendName::all().iter().enumerate() {
             println!("  {DIM}{}){RESET} {}", i + 1, b.as_str());
         }
+        // Blank line so the list and the prompt don't crowd each other.
+        println!();
         let prompt = format!("  {DIM}Select (1-{}):{RESET} ", BackendName::all().len());
         let pick = plain_read_line(prompt).await?.trim().to_string();
+        // Blank line between the typed selection and the response below.
+        println!();
         pick.parse::<usize>()
             .ok()
             .and_then(|n| n.checked_sub(1))
@@ -633,8 +637,12 @@ pub(super) async fn cmd_model(args: &str, state: &mut AppState) -> Result<()> {
     if total > shown.len() {
         println!("  {DIM}…and {} more{RESET}", total - shown.len());
     }
+    // Blank line so the list and the prompt don't crowd each other.
+    println!();
     let prompt = format!("  {DIM}Select (1-{}):{RESET} ", shown.len());
     let pick = plain_read_line(prompt).await?.trim().to_string();
+    // Blank line between the typed selection and the response below.
+    println!();
     if let Some(idx) = pick.parse::<usize>().ok().and_then(|n| n.checked_sub(1)) {
         if let Some(m) = shown.get(idx) {
             state.config.model_override = Some(m.clone());

--- a/src/input.rs
+++ b/src/input.rs
@@ -353,16 +353,20 @@ fn read_plain_outcome(
                     continue;
                 }
                 if let Some(outcome) = control_key_outcome(code, modifiers) {
+                    // See the Enter branch: `\r\n`, not `\n`, while raw mode is on.
                     redraw(&mut out, &chars, cursor, sel, true)?;
-                    writeln!(out)?;
+                    write!(out, "\r\n")?;
                     out.flush()?;
                     return Ok(outcome);
                 }
                 match code {
                     KeyCode::Enter => {
-                        // Clear any open menu, then drop to the next line.
+                        // Clear any open menu, then drop to the next line. Raw mode
+                        // is still active here, so a bare `\n` only line-feeds and
+                        // leaves the cursor in the input's last column — `\r` returns
+                        // it to column 0 so the caller's output isn't shifted right.
                         redraw(&mut out, &chars, cursor, sel, true)?;
-                        writeln!(out)?;
+                        write!(out, "\r\n")?;
                         out.flush()?;
                         return Ok(ReadLineOutcome::Line(chars.iter().collect()));
                     }


### PR DESCRIPTION
## Summary

- Interactive sub-prompt readers (`/backend`, `/model`, filters, `y/N` confirms,
  and every other `plain_read_line` caller) emitted a bare `\n` on Enter — and
  on Ctrl+C/Ctrl+D — while the terminal was still in raw mode.
- In raw mode `\n` is a line feed only: the cursor drops one row but stays in
  the input's last column, so the first line the command printed afterwards
  (the `✓` confirmation, a picker's first row) began far to the right.
- Emit `\r\n` instead so the cursor returns to column 0 before the caller prints.
- Pre-existing bug, not introduced by any recent feature; it was just more
  visible in submenus that print several lines right after a selection.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test` (input module + full suite pass)

## Screenshots

### Before

<img width="401" height="191" alt="image" src="https://github.com/user-attachments/assets/e4e3bd41-6964-4806-b3c9-6574516c8ca7" />

### After

<img width="372" height="231" alt="image" src="https://github.com/user-attachments/assets/5cdba5ef-075b-4f23-bedc-b5080a88e90f" />