### PR TITLE
fix: default /login and /logout to the active OAuth backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -384,6 +384,8 @@ this exact call`. The session cache resets on `/new`.
 /model [id] [--default]      list / pick a model; --default pins backend+model
 /tools auto|fixed|<…>  show or set the active tool pool
 /auth                  manage API keys and OAuth credentials
+/login [provider]      sign in (defaults to active OAuth backend)
+/logout [provider]     clear stored OAuth login (defaults to active OAuth backend)
 /login openai-codex    sign in with ChatGPT/Codex subscription OAuth
 /logout openai-codex   clear the stored ChatGPT/Codex login
 /login grok            sign in with SuperGrok / X Premium+ OAuth
@@ -433,11 +435,18 @@ no change in behavior.
 /auth set openai         paste your OpenAI key, save to file + this session
 /auth set openrouter     paste your OpenRouter key
 /auth clear openai       remove from the file (env stays for this session)
+/login                   browser/device-code login for the active OAuth backend
+/logout                  clear stored login for the active OAuth backend
 /login openai-codex      browser/device-code login with ChatGPT/Codex
 /logout openai-codex     remove the stored OAuth credential
 /login grok              browser/device-code login with SuperGrok / X Premium+
 /logout grok             remove the stored Grok OAuth credential
 ```
+
+Bare `/login` and `/logout` use the **active OAuth backend** (`grok` or
+`openai-codex`). On a non-OAuth backend (or via `/auth login` with no
+provider), pass the provider explicitly.
+
 
 `openai-codex` is not an `OPENAI_API_KEY` replacement. It uses browser/device
 OAuth, stores `{access, refresh, expires, accountId}` in the same `auth.json`,

--- a/src/commands/config_cmds.rs
+++ b/src/commands/config_cmds.rs
@@ -212,20 +212,68 @@ pub(super) async fn cmd_auth(args: &str) -> Result<()> {
 
 struct AppStateLoginOnly;
 
+/// Explicit OAuth provider names accepted by `/login` / `/logout`.
 fn normalize_login_provider(raw: &str) -> Option<&'static str> {
     match raw.trim().to_ascii_lowercase().as_str() {
-        "" | "openai-codex" | "codex" | "chatgpt" => Some("openai-codex"),
+        "openai-codex" | "codex" | "chatgpt" => Some("openai-codex"),
         "grok" | "xai" | "xai-oauth" | "x-ai" | "supergrok" | "grok-oauth" => Some("grok"),
         _ => None,
     }
 }
 
+/// Resolve which OAuth provider `/login` / `/logout` should target.
+///
+/// - Explicit args win (`/logout grok`, `/login codex`, …).
+/// - Bare commands use the **active OAuth backend** when the session is on
+///   `grok` or `openai-codex`.
+/// - Bare commands with a non-OAuth backend (or no backend context, e.g.
+///   `/auth login`) require an explicit provider — no silent Codex default.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum LoginProviderResolve {
+    Provider(&'static str),
+    NeedProvider,
+    Unknown,
+}
+
+fn resolve_login_provider(
+    raw: &str,
+    active_backend: Option<crate::backends::BackendName>,
+) -> LoginProviderResolve {
+    let trimmed = raw.trim();
+    if !trimmed.is_empty() {
+        return match normalize_login_provider(trimmed) {
+            Some(p) => LoginProviderResolve::Provider(p),
+            None => LoginProviderResolve::Unknown,
+        };
+    }
+    match active_backend {
+        Some(b) if b.is_oauth_login() => LoginProviderResolve::Provider(b.as_str()),
+        _ => LoginProviderResolve::NeedProvider,
+    }
+}
+
+fn print_login_provider_error(action: &str, args: &str, resolve: LoginProviderResolve) {
+    match resolve {
+        LoginProviderResolve::NeedProvider => {
+            println!(
+                "  {RED}✗{RESET} {DIM}usage: /{action} <openai-codex|grok> \
+                 (or switch to an OAuth backend first){RESET}"
+            );
+        }
+        LoginProviderResolve::Unknown => {
+            println!(
+                "  {RED}✗{RESET} {DIM}unknown {action} provider: {} (try: openai-codex, grok){RESET}",
+                args.trim()
+            );
+        }
+        LoginProviderResolve::Provider(_) => {}
+    }
+}
+
 pub(super) async fn cmd_login(args: &str, state: &mut impl LoginState) -> Result<()> {
-    let Some(provider) = normalize_login_provider(args) else {
-        println!(
-            "  {RED}✗{RESET} {DIM}unknown login provider: {} (try: openai-codex, grok){RESET}",
-            args.trim()
-        );
+    let resolve = resolve_login_provider(args, state.active_backend());
+    let LoginProviderResolve::Provider(provider) = resolve else {
+        print_login_provider_error("login", args, resolve);
         return Ok(());
     };
 
@@ -267,6 +315,9 @@ pub(super) async fn cmd_login(args: &str, state: &mut impl LoginState) -> Result
 pub(super) trait LoginState {
     fn http(&self) -> &reqwest::Client;
     fn after_login(&mut self) -> Result<()>;
+    /// Active backend for bare `/login` defaulting. `None` when there is no
+    /// session context (e.g. `/auth login`).
+    fn active_backend(&self) -> Option<crate::backends::BackendName>;
 }
 
 impl LoginState for AppState {
@@ -280,6 +331,9 @@ impl LoginState for AppState {
         }
         Ok(())
     }
+    fn active_backend(&self) -> Option<crate::backends::BackendName> {
+        Some(self.config.backend)
+    }
 }
 
 impl LoginState for AppStateLoginOnly {
@@ -290,14 +344,18 @@ impl LoginState for AppStateLoginOnly {
     fn after_login(&mut self) -> Result<()> {
         Ok(())
     }
+    fn active_backend(&self) -> Option<crate::backends::BackendName> {
+        None
+    }
 }
 
-pub(super) fn cmd_logout(args: &str) -> Result<()> {
-    let Some(provider) = normalize_login_provider(args) else {
-        println!(
-            "  {RED}✗{RESET} {DIM}unknown logout provider: {} (try: openai-codex, grok){RESET}",
-            args.trim()
-        );
+pub(super) fn cmd_logout(
+    args: &str,
+    active_backend: Option<crate::backends::BackendName>,
+) -> Result<()> {
+    let resolve = resolve_login_provider(args, active_backend);
+    let LoginProviderResolve::Provider(provider) = resolve else {
+        print_login_provider_error("logout", args, resolve);
         return Ok(());
     };
     let mut store = crate::auth::AuthStore::load();
@@ -1307,6 +1365,53 @@ mod tests {
         assert_eq!(state.config.mode, OperatorMode::Ship);
         assert!(state.config.checkpoints.enabled);
         assert!(state.checkpoints_enabled);
+    }
+
+    #[test]
+    fn resolve_login_provider_explicit_aliases() {
+        use crate::backends::BackendName;
+        assert_eq!(
+            resolve_login_provider("codex", Some(BackendName::Grok)),
+            LoginProviderResolve::Provider("openai-codex")
+        );
+        assert_eq!(
+            resolve_login_provider("xai", Some(BackendName::OpenAiCodex)),
+            LoginProviderResolve::Provider("grok")
+        );
+        assert_eq!(
+            resolve_login_provider("nope", None),
+            LoginProviderResolve::Unknown
+        );
+    }
+
+    #[test]
+    fn resolve_login_provider_bare_uses_active_oauth_backend() {
+        use crate::backends::BackendName;
+        assert_eq!(
+            resolve_login_provider("", Some(BackendName::Grok)),
+            LoginProviderResolve::Provider("grok")
+        );
+        assert_eq!(
+            resolve_login_provider("  ", Some(BackendName::OpenAiCodex)),
+            LoginProviderResolve::Provider("openai-codex")
+        );
+    }
+
+    #[test]
+    fn resolve_login_provider_bare_requires_provider_without_oauth_backend() {
+        use crate::backends::BackendName;
+        assert_eq!(
+            resolve_login_provider("", Some(BackendName::Ollama)),
+            LoginProviderResolve::NeedProvider
+        );
+        assert_eq!(
+            resolve_login_provider("", Some(BackendName::OpenAi)),
+            LoginProviderResolve::NeedProvider
+        );
+        assert_eq!(
+            resolve_login_provider("", None),
+            LoginProviderResolve::NeedProvider
+        );
     }
 
     #[test]

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -165,9 +165,12 @@ pub const COMMANDS: &[(&str, &str)] = &[
     ),
     (
         "/login",
-        "Browser/device-code login for subscription providers (openai-codex, grok)",
+        "Browser/device-code login (defaults to active OAuth backend: openai-codex, grok)",
     ),
-    ("/logout", "Clear an OAuth login (openai-codex, grok)"),
+    (
+        "/logout",
+        "Clear an OAuth login (defaults to active OAuth backend: openai-codex, grok)",
+    ),
     (
         "/image",
         "Attach an image to the next user prompt (vision-capable models only)",
@@ -287,7 +290,7 @@ pub async fn dispatch(input: &str, state: &mut AppState) -> Result<()> {
         "/export" => session::cmd_export(&args, state)?,
         "/auth" => config_cmds::cmd_auth(&args).await?,
         "/login" => config_cmds::cmd_login(&args, state).await?,
-        "/logout" => config_cmds::cmd_logout(&args)?,
+        "/logout" => config_cmds::cmd_logout(&args, Some(state.config.backend))?,
         "/image" => config_cmds::cmd_image(&args, state),
         "/reasoning" => config_cmds::cmd_reasoning(&args, state),
         "/verbose" => config_cmds::cmd_verbose(&args, state),


### PR DESCRIPTION
## Motivation

With `backend: grok` and a Grok model selected, bare `/logout` printed
`no stored openai-codex login`. That looked like a Grok auth failure, but
empty-arg `/login` and `/logout` always defaulted to `openai-codex` and
never consulted the active backend.

This change makes bare OAuth commands follow the active OAuth backend so the
message matches what the banner already shows.

## Summary of changes

### Provider resolution
- Bare `/login` / `/logout` use the active OAuth backend when it is `grok` or
  `openai-codex`
- On a non-OAuth backend (or `/auth login` with no session context), require an
  explicit provider instead of silently assuming Codex
- Explicit providers still win (`/logout grok`, `/login codex`, …)

### Docs / help
- Update README and `/help` text so bare commands document the active-backend
  default

### Tests
- Cover explicit aliases, bare + active OAuth backend, and bare without an
  OAuth backend

## Verified by

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test resolve_login_provider`
- [x] Manual: `backend grok` → `/logout` mentions `grok` (not `openai-codex`)
- [x] Manual: non-OAuth backend → bare `/logout` prints usage

## Screenshots

### Before

<img width="1455" height="785" alt="image" src="https://github.com/user-attachments/assets/025ee439-adbf-4211-a963-529484d8a9b7" />

### After

<img width="1389" height="834" alt="image" src="https://github.com/user-attachments/assets/5526960d-c983-4682-870b-4774161ef6fb" />

<img width="1408" height="735" alt="image" src="https://github.com/user-attachments/assets/8ee39b0c-ac23-4fde-9abd-61b7ae9b0c20" />

<img width="901" height="1064" alt="image" src="https://github.com/user-attachments/assets/aebb5649-ced1-4f32-945b-3e772ce24ff9" />