### PR TITLE
fix: streamline OAuth backend switching and CLI credential reuse

### DIFF
--- a/src/codex_oauth.rs
+++ b/src/codex_oauth.rs
@@ -276,6 +276,71 @@ fn save_oauth(credential: OAuthCredential) -> Result<PathBuf> {
     auth_file_path().context("no auth file path")
 }
 
+fn token_expiration(token: &str) -> Option<u64> {
+    let payload = token.split('.').nth(1)?;
+    let decoded = URL_SAFE_NO_PAD.decode(payload).ok()?;
+    serde_json::from_slice::<Value>(&decoded)
+        .ok()?
+        .get("exp")?
+        .as_u64()
+}
+
+fn parse_codex_cli_credentials(data: &Value) -> Option<OAuthCredential> {
+    let tokens = data.get("tokens").unwrap_or(data);
+    let access = tokens.get("access_token")?.as_str()?.to_string();
+    if access.is_empty() {
+        return None;
+    }
+    let refresh = tokens
+        .get("refresh_token")
+        .and_then(|value| value.as_str())
+        .unwrap_or("")
+        .to_string();
+    let account_id = tokens
+        .get("account_id")
+        .or_else(|| tokens.get("accountId"))
+        .and_then(|value| value.as_str())
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+        .or_else(|| account_id_from_access_token(&access));
+    Some(OAuthCredential {
+        credential_type: "oauth".into(),
+        expires: token_expiration(&access).unwrap_or_else(|| now_secs() + 3600),
+        access,
+        refresh,
+        account_id,
+    })
+}
+
+pub fn load_codex_cli_credentials() -> Option<OAuthCredential> {
+    let home = std::env::var_os("HOME")?;
+    let path = PathBuf::from(home).join(".codex").join("auth.json");
+    let text = std::fs::read_to_string(path).ok()?;
+    parse_codex_cli_credentials(&serde_json::from_str(&text).ok()?)
+}
+
+pub async fn import_codex_cli_credentials(client: &reqwest::Client) -> Result<Option<PathBuf>> {
+    let Some(existing) = load_codex_cli_credentials() else {
+        return Ok(None);
+    };
+    let credential = if existing.expires <= now_secs() + 60 {
+        if existing.refresh.is_empty() {
+            println!("  Stored Codex CLI token is expired and has no refresh token.");
+            return Ok(None);
+        }
+        match refresh_oauth(client, &existing.refresh).await {
+            Ok(refreshed) => refreshed,
+            Err(e) => {
+                println!("  Could not refresh Codex CLI credentials ({e}); starting fresh login.");
+                return Ok(None);
+            }
+        }
+    } else {
+        existing
+    };
+    save_oauth(credential).map(Some)
+}
+
 pub async fn login_browser(client: &reqwest::Client) -> Result<OAuthCredential> {
     let (verifier, challenge) = pkce_pair();
     let state = random_hex(16);
@@ -455,5 +520,21 @@ mod tests {
         );
         assert_eq!(code.as_deref(), Some("abc 123"));
         assert_eq!(state.as_deref(), Some("st"));
+    }
+
+    #[test]
+    fn parses_codex_cli_credentials() {
+        let auth = serde_json::json!({
+            "tokens": {
+                "access_token": "access",
+                "refresh_token": "refresh",
+                "account_id": "account"
+            }
+        });
+
+        let credential = parse_codex_cli_credentials(&auth).expect("credential");
+        assert_eq!(credential.access, "access");
+        assert_eq!(credential.refresh, "refresh");
+        assert_eq!(credential.account_id.as_deref(), Some("account"));
     }
 }

--- a/src/commands/config_cmds.rs
+++ b/src/commands/config_cmds.rs
@@ -675,6 +675,15 @@ async fn maybe_persist_backend_default(state: &AppState, as_default: bool) -> Re
     Ok(())
 }
 
+fn activate_backend_for_login(state: &mut AppState, chosen: BackendName) {
+    state.config.backend = chosen;
+    state.config.model_override = None;
+    state.active_effort = None;
+    state.active_route = None;
+    state.backend = backend(chosen);
+    state.resolve_model();
+}
+
 pub(super) async fn cmd_backend(args: &str, state: &mut AppState) -> Result<()> {
     let (rest, as_default) = crate::config::strip_default_flag(args);
 
@@ -716,26 +725,21 @@ pub(super) async fn cmd_backend(args: &str, state: &mut AppState) -> Result<()> 
         println!("  {DIM}Cancelled.{RESET}");
         return Ok(());
     };
-    if matches!(chosen, BackendName::OpenAiCodex)
+    let login_required = if matches!(chosen, BackendName::OpenAiCodex)
         && crate::auth::AuthStore::load()
             .get_oauth("openai-codex")
             .is_none()
     {
-        println!(
-            "  {RED}✗{RESET} {DIM}not logged in for openai-codex. Run /login openai-codex to sign in with ChatGPT.{RESET}"
-        );
-        return Ok(());
-    }
-    if matches!(chosen, BackendName::Grok)
+        Some("not logged in for openai-codex. Run /login to sign in with ChatGPT.")
+    } else if matches!(chosen, BackendName::Grok)
         && crate::auth::AuthStore::load()
             .get_oauth(crate::xai_oauth::PROVIDER)
             .is_none()
     {
-        println!(
-            "  {RED}✗{RESET} {DIM}not logged in for grok. Run /login grok to sign in with SuperGrok / X Premium+.{RESET}"
-        );
-        return Ok(());
-    }
+        Some("not logged in for grok. Run /login to sign in with SuperGrok / X Premium+.")
+    } else {
+        None
+    };
     if !chosen.is_local() && !chosen.is_oauth_login() && backend(chosen).api_key.is_empty() {
         let env_name = match chosen {
             BackendName::Openrouter => "OPENROUTER_API_KEY",
@@ -747,17 +751,18 @@ pub(super) async fn cmd_backend(args: &str, state: &mut AppState) -> Result<()> 
         println!("  {RED}✗{RESET} {DIM}{env_name} not set in environment.{RESET}");
         return Ok(());
     }
-    state.config.backend = chosen;
-    state.config.model_override = None;
-    state.active_effort = None;
-    state.active_route = None;
-    state.rebuild_client()?;
-    state.resolve_model();
+    activate_backend_for_login(state, chosen);
+    if login_required.is_none() {
+        state.rebuild_client()?;
+    }
     println!(
         "  {GREEN}✓{RESET} {DIM}backend →{RESET} {CYAN}{}{RESET} {DIM}· model →{RESET} {CYAN}{}{RESET}",
         chosen.as_str(),
         state.model
     );
+    if let Some(message) = login_required {
+        println!("  {YELLOW}!{RESET} {DIM}{message}{RESET}");
+    }
     // Direct `/backend name --default` skips the confirm; the arrow picker
     // offers to save the selected backend after applying it to this session.
     if rest.is_empty() {
@@ -1457,6 +1462,25 @@ mod tests {
             resolve_login_provider("", None),
             LoginProviderResolve::NeedProvider
         );
+    }
+
+    #[test]
+    fn selecting_an_unauthenticated_oauth_backend_updates_login_target_and_model() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut state = test_state(dir.path());
+
+        activate_backend_for_login(&mut state, BackendName::OpenAiCodex);
+
+        assert_eq!(state.config.backend, BackendName::OpenAiCodex);
+        assert_eq!(state.backend.name, BackendName::OpenAiCodex);
+        assert_eq!(state.model, "gpt-5.5");
+    }
+
+    #[test]
+    fn cli_import_prompt_defaults_to_import_and_allows_declining() {
+        assert!(should_use_cli_credentials(""));
+        assert!(should_use_cli_credentials("YES"));
+        assert!(!should_use_cli_credentials("n"));
     }
 
     #[test]

--- a/src/commands/config_cmds.rs
+++ b/src/commands/config_cmds.rs
@@ -270,6 +270,13 @@ fn print_login_provider_error(action: &str, args: &str, resolve: LoginProviderRe
     }
 }
 
+fn should_use_cli_credentials(answer: &str) -> bool {
+    matches!(
+        answer.trim().to_ascii_lowercase().as_str(),
+        "" | "y" | "yes"
+    )
+}
+
 pub(super) async fn cmd_login(args: &str, state: &mut impl LoginState) -> Result<()> {
     let resolve = resolve_login_provider(args, state.active_backend());
     let LoginProviderResolve::Provider(provider) = resolve else {
@@ -289,6 +296,37 @@ pub(super) async fn cmd_login(args: &str, state: &mut impl LoginState) -> Result
     };
     println!("  {BOLD}{title}{RESET}");
     println!("  {DIM}{note}{RESET}");
+    let cli_credentials = match provider {
+        "grok" if crate::xai_oauth::load_grok_cli_credentials().is_some() => {
+            Some(("Grok", "~/.grok/auth.json"))
+        }
+        "openai-codex" if crate::codex_oauth::load_codex_cli_credentials().is_some() => {
+            Some(("Codex", "~/.codex/auth.json"))
+        }
+        _ => None,
+    };
+    if let Some((cli_name, cli_path)) = cli_credentials {
+        println!("  Found existing {cli_name} CLI credentials in {cli_path}.");
+        let pick =
+            plain_read_line("  Use them instead of a new OAuth login? [Y/n]: ".into()).await?;
+        if should_use_cli_credentials(&pick) {
+            let path = match provider {
+                "grok" => crate::xai_oauth::import_grok_cli_credentials(state.http()).await?,
+                "openai-codex" => {
+                    crate::codex_oauth::import_codex_cli_credentials(state.http()).await?
+                }
+                _ => None,
+            };
+            if let Some(path) = path {
+                println!(
+                    "  {GREEN}✓{RESET} {DIM}logged in to {provider}; saved to {}{RESET}",
+                    path.display()
+                );
+                state.after_login()?;
+                return Ok(());
+            }
+        }
+    }
     println!("  {DIM}1) Browser login (default){RESET}");
     println!("  {DIM}2) Device-code login (headless/SSH){RESET}");
     let pick = plain_read_line(format!("  {DIM}Select [1]: {RESET}")).await?;

--- a/src/xai_oauth.rs
+++ b/src/xai_oauth.rs
@@ -706,45 +706,35 @@ pub fn load_grok_cli_credentials() -> Option<OAuthCredential> {
     try_entry(&data)
 }
 
-async fn maybe_import_grok_cli(client: &reqwest::Client) -> Result<Option<OAuthCredential>> {
+pub async fn import_grok_cli_credentials(client: &reqwest::Client) -> Result<Option<PathBuf>> {
     let Some(existing) = load_grok_cli_credentials() else {
         return Ok(None);
     };
-    println!("  Found existing Grok CLI credentials in ~/.grok/auth.json.");
-    let pick = plain_read_line("  Use them instead of a new OAuth login? [Y/n]: ".into()).await?;
-    let trimmed = pick.trim().to_lowercase();
-    if trimmed.is_empty() || trimmed == "y" || trimmed == "yes" {
-        if existing.expires <= now_secs() + 60 {
-            if existing.refresh.is_empty() {
-                println!("  Stored Grok CLI token is expired and has no refresh token.");
+    let credential = if existing.expires <= now_secs() + 60 {
+        if existing.refresh.is_empty() {
+            println!("  Stored Grok CLI token is expired and has no refresh token.");
+            return Ok(None);
+        }
+        match refresh_oauth(
+            client,
+            &existing.refresh,
+            Some(&format!("{ISSUER}/oauth2/token")),
+        )
+        .await
+        {
+            Ok(refreshed) => refreshed,
+            Err(e) => {
+                println!("  Could not refresh Grok CLI credentials ({e}); starting fresh login.");
                 return Ok(None);
             }
-            match refresh_oauth(
-                client,
-                &existing.refresh,
-                Some(&format!("{ISSUER}/oauth2/token")),
-            )
-            .await
-            {
-                Ok(refreshed) => return Ok(Some(refreshed)),
-                Err(e) => {
-                    println!(
-                        "  Could not refresh Grok CLI credentials ({e}); starting fresh login."
-                    );
-                    return Ok(None);
-                }
-            }
         }
-        return Ok(Some(existing));
-    }
-    Ok(None)
+    } else {
+        existing
+    };
+    save_oauth(credential).map(Some)
 }
 
 pub async fn login_browser(client: &reqwest::Client) -> Result<OAuthCredential> {
-    if let Some(imported) = maybe_import_grok_cli(client).await? {
-        return Ok(imported);
-    }
-
     let discovery = discover(client).await?;
     let (verifier, challenge) = pkce_pair();
     let state = random_hex(16);
@@ -810,10 +800,6 @@ struct DeviceStartResponse {
 }
 
 pub async fn login_device_code(client: &reqwest::Client) -> Result<OAuthCredential> {
-    if let Some(imported) = maybe_import_grok_cli(client).await? {
-        return Ok(imported);
-    }
-
     let discovery = discover(client).await?;
     let body = form_urlencoded(&[("client_id", CLIENT_ID), ("scope", SCOPE)]);
     let resp = client


### PR DESCRIPTION
## Motivation

The OAuth onboarding flow had two connected issues:

- `/login` showed browser/device-code choices before offering reusable Grok CLI credentials, and Codex CLI credentials were not reusable at all.
- Selecting an unauthenticated OAuth backend from `/backend` reported that login was missing but left the live session on the previous backend/model. A following bare `/login` therefore targeted the old provider.

This change makes switching to an OAuth backend and signing in behave as one coherent flow.

## Summary of changes

### CLI credential reuse

- Detect existing Grok CLI credentials in `~/.grok/auth.json` before showing fresh OAuth options
- Add the same import-first flow for Codex CLI credentials in `~/.codex/auth.json`
- Default to importing existing credentials; declining continues to browser/device-code login
- Refresh imported credentials when necessary before saving them into Albatross’s auth store

### OAuth backend selection

- Allow `/backend grok` and `/backend openai-codex` to become the active session backend even when login is still required
- Reset the live model to the selected backend’s default model
- Show a login-required warning after switching instead of rejecting the selection
- Bare `/login` now follows the newly selected OAuth backend

### Tests

- Cover Codex CLI credential parsing
- Cover the CLI-import prompt’s default and decline behavior
- Cover selecting an unauthenticated OAuth backend updates both the login target and default model

## Verified by

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test` (651 passed)

## Screenshots

### Before

#### CLI credential import appears after choosing a login method

<img width="1093" height="283" alt="image" src="https://github.com/user-attachments/assets/321c7889-07c5-46f1-b562-f0b397af10bb" />

#### Unauthenticated OAuth backend selection is rejected

<img width="1190" height="731" alt="image" src="https://github.com/user-attachments/assets/03b828e7-4e9f-4fe2-ad08-85e02e4dd83f" />

### After

#### CLI credential import is offered before login-method selection

<img width="1083" height="300" alt="image" src="https://github.com/user-attachments/assets/732051bc-25e0-4c41-8a04-5402c88d93e5" />

#### Backend switches to the selected OAuth provider and guides login

<img width="1108" height="810" alt="image" src="https://github.com/user-attachments/assets/9bb801a9-eef1-405f-8543-c5d08fead9a1" />