### PR TITLE
fix: prevent loader from corrupting approval input

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -44,6 +44,12 @@ pub enum AgentEvent {
         args: Value,
         depth: u32,
     },
+    /// The tool passed all approval and hook gates and is about to execute.
+    /// This is deliberately separate from `ToolCall`: interactive approval
+    /// owns the terminal between the two events.
+    ToolExecutionStarted {
+        name: String,
+    },
     ToolResult {
         name: String,
         call_id: String,
@@ -762,6 +768,18 @@ where
             content: assistant_content,
             tool_calls: tcs.clone(),
         });
+
+        // `ToolCall` is announced before approval so the user can inspect the
+        // request. Only emit the execution event after every approval gate has
+        // resolved; the terminal can then safely show an animated progress
+        // indicator without corrupting the approval input line.
+        for (tc, entry) in tcs.iter().zip(pending.iter()) {
+            if matches!(entry, Pending::Run { .. }) {
+                on_event(AgentEvent::ToolExecutionStarted {
+                    name: tc.function.name.clone(),
+                });
+            }
+        }
 
         fn value_to_string(result: &Value) -> String {
             if let Some(s) = result.as_str() {

--- a/src/agent_integration_test.rs
+++ b/src/agent_integration_test.rs
@@ -13,6 +13,34 @@ use crate::config::AgentConfig;
 use crate::openai::{build_http_client, ChatMessage};
 use crate::tools::{build_tools_for_names, SubagentTool, Tool};
 
+struct AllowApproval;
+
+#[async_trait::async_trait]
+impl crate::agent::ApprovalProvider for AllowApproval {
+    async fn approve(
+        &mut self,
+        _name: &str,
+        _args: &serde_json::Value,
+        _preview: Option<&crate::tools::ToolPreview>,
+    ) -> bool {
+        true
+    }
+}
+
+struct DenyApproval;
+
+#[async_trait::async_trait]
+impl crate::agent::ApprovalProvider for DenyApproval {
+    async fn approve(
+        &mut self,
+        _name: &str,
+        _args: &serde_json::Value,
+        _preview: Option<&crate::tools::ToolPreview>,
+    ) -> bool {
+        false
+    }
+}
+
 fn mock_backend(listener: &TcpListener) -> BackendDescriptor {
     BackendDescriptor {
         name: BackendName::Ollama,
@@ -123,6 +151,114 @@ async fn read_and_explain_mock_loop() {
     let checks = evaluate_checks(&fixture_workspace(), &fixture.checks, &run, &tool_calls);
     assert!(checks.iter().all(|c| c.passed), "{checks:?}");
     assert!(!run.hit_step_limit);
+}
+
+#[tokio::test]
+async fn execution_status_follows_approval() {
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let backend_desc = mock_backend(&listener);
+    let tool_call_body = concat!(
+        "data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"id\":\"call_1\",\"function\":",
+        "{\"name\":\"shell\",\"arguments\":\"{\\\"command\\\":\\\"true\\\"}\"}}]}}]}\n\n",
+        "data: [DONE]\n\n"
+    );
+    let answer_body = concat!(
+        "data: {\"choices\":[{\"delta\":{\"content\":\"Done.\"}}]}\n\n",
+        "data: [DONE]\n\n"
+    );
+    let server = spawn_mock_server(listener, vec![tool_call_body, answer_body]);
+
+    let mut config = AgentConfig::default();
+    config.workspace_root = fixture_workspace().display().to_string();
+    config.approval_policy = crate::config::ApprovalPolicy::Always;
+    config.tools = vec!["shell".into()];
+    config.tool_selection = crate::config::ToolSelection::Fixed;
+    let tools = build_tools_for_names(&config, &config.tools, None);
+    let http = build_http_client();
+    let mut events = Vec::new();
+    let mut approval = AllowApproval;
+
+    run_agent(
+        &http,
+        &backend_desc,
+        "mock",
+        None,
+        vec![ChatMessage::User {
+            content: "Run true.".into(),
+        }],
+        tools,
+        4,
+        |event| match event {
+            AgentEvent::ToolCall { .. } => events.push("announced"),
+            AgentEvent::ToolExecutionStarted { .. } => events.push("running"),
+            _ => {}
+        },
+        Some(&mut approval),
+        None,
+        None,
+        None,
+        None,
+        0,
+        None,
+    )
+    .await
+    .unwrap();
+
+    server.join().unwrap();
+    assert_eq!(events, ["announced", "running"]);
+}
+
+#[tokio::test]
+async fn denied_tool_never_emits_execution_status() {
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let backend_desc = mock_backend(&listener);
+    let tool_call_body = concat!(
+        "data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"id\":\"call_1\",\"function\":",
+        "{\"name\":\"shell\",\"arguments\":\"{\\\"command\\\":\\\"true\\\"}\"}}]}}]}\n\n",
+        "data: [DONE]\n\n"
+    );
+    let answer_body = concat!(
+        "data: {\"choices\":[{\"delta\":{\"content\":\"Denied.\"}}]}\n\n",
+        "data: [DONE]\n\n"
+    );
+    let server = spawn_mock_server(listener, vec![tool_call_body, answer_body]);
+
+    let mut config = AgentConfig::default();
+    config.workspace_root = fixture_workspace().display().to_string();
+    config.approval_policy = crate::config::ApprovalPolicy::Always;
+    config.tools = vec!["shell".into()];
+    config.tool_selection = crate::config::ToolSelection::Fixed;
+    let tools = build_tools_for_names(&config, &config.tools, None);
+    let http = build_http_client();
+    let mut execution_started = false;
+    let mut approval = DenyApproval;
+
+    run_agent(
+        &http,
+        &backend_desc,
+        "mock",
+        None,
+        vec![ChatMessage::User {
+            content: "Run true.".into(),
+        }],
+        tools,
+        4,
+        |event| {
+            execution_started |= matches!(event, AgentEvent::ToolExecutionStarted { .. });
+        },
+        Some(&mut approval),
+        None,
+        None,
+        None,
+        None,
+        0,
+        None,
+    )
+    .await
+    .unwrap();
+
+    server.join().unwrap();
+    assert!(!execution_started);
 }
 
 #[tokio::test]

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -462,6 +462,9 @@ impl TuiRenderer {
                 self.end_answer();
                 self.render_tool_call(&name, &call_id, args, depth)
             }
+            // Progress is rendered by the session loader. Keeping this out of
+            // the transcript avoids duplicate tool rows.
+            AgentEvent::ToolExecutionStarted { .. } => {}
             AgentEvent::ToolResult {
                 name,
                 call_id,

--- a/src/session_turn.rs
+++ b/src/session_turn.rs
@@ -795,6 +795,8 @@ pub async fn run_user_turn(state: &mut AppState, opts: TurnOptions) -> Result<Tu
             }
             if let AgentEvent::ToolCall { name, .. } = &e {
                 tool_calls.push(name.clone());
+            }
+            if let AgentEvent::ToolExecutionStarted { name, .. } = &e {
                 if let Some(loader) = loader_opt.as_mut() {
                     loader.set_text(format!("Running {name}…"));
                 } else {


### PR DESCRIPTION
## Motivation

Approval prompts could become unusable because the animated `Running shell…` loader started before the user had approved the tool call, overwriting the raw input line.

## Summary of changes

### Approval-safe execution status

- Add a `ToolExecutionStarted` event emitted only after approval and hook gates succeed.
- Start the animated tool loader from that event, rather than from the initial tool-call announcement.
- Keep the tool-call row visible without adding a duplicate transcript row.
- Ensure denied tools never emit a running status.

## Verified by

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test` (650 passed)

## Screenshots

### Before

<img width="1184" height="443" alt="image" src="https://github.com/user-attachments/assets/bfa1b0e5-94f6-44b8-8340-8ded977d5c5c" />

### After

<img width="1261" height="748" alt="image" src="https://github.com/user-attachments/assets/dfb08e37-48a4-420d-8681-017b1c673a95" />