### PR TITLE
docs: replace plain title with theme-aware ASCII wordmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-<h1 align="center">Albatross</h1>
+<p align="center">
+  <img alt="Albatross" src="docs/assets/demo/albatross-wordmark.svg" width="720">
+</p>
 
 <p align="center">
   <strong>A small, terminal-first coding harness. Bring your own model, your own key, or your own MCP server.</strong>

--- a/docs/assets/demo/README.md
+++ b/docs/assets/demo/README.md
@@ -1,0 +1,5 @@
+# README media
+
+| File | What |
+|------|------|
+| `albatross-wordmark.svg` | Transparent ASCII wordmark (follows light/dark page theme) |

--- a/docs/assets/demo/albatross-wordmark.svg
+++ b/docs/assets/demo/albatross-wordmark.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="616" height="122" viewBox="0 0 616 122" role="img" aria-label="Albatross">
+  <title>Albatross</title>
+  <style>
+    text {
+      fill: #1f2328;
+      font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+      font-size: 13px;
+      font-weight: 700;
+      white-space: pre;
+    }
+    @media (prefers-color-scheme: dark) {
+      text { fill: #e6edf3; }
+    }
+  </style>
+  <text x="8" y="23">   █████╗ ██╗     ██████╗  █████╗ ████████╗██████╗  ██████╗ ███████╗███████╗</text>
+  <text x="8" y="40">  ██╔══██╗██║     ██╔══██╗██╔══██╗╚══██╔══╝██╔══██╗██╔═══██╗██╔════╝██╔════╝</text>
+  <text x="8" y="57">  ███████║██║     ██████╔╝███████║   ██║   ██████╔╝██║   ██║███████╗███████╗</text>
+  <text x="8" y="74">  ██╔══██║██║     ██╔══██╗██╔══██║   ██║   ██╔══██╗██║   ██║╚════██║╚════██║</text>
+  <text x="8" y="91">  ██║  ██║███████╗██████╔╝██║  ██║   ██║   ██║  ██║╚██████╔╝███████║███████║</text>
+  <text x="8" y="108">  ╚═╝  ╚═╝╚══════╝╚═════╝ ╚═╝  ╚═╝   ╚═╝   ╚═╝  ╚═╝ ╚═════╝ ╚══════╝╚══════╝</text>
+</svg>


### PR DESCRIPTION
Replace the plain `Albatross` H1 with the banner wordmark as a transparent SVG.

No gray code-block background, and `prefers-color-scheme` keeps it readable on light and dark GitHub themes.