### PR TITLE
docs: use provider command in demo tape

### DIFF
--- a/docs/tapes/agent-session.tape
+++ b/docs/tapes/agent-session.tape
@@ -50,7 +50,7 @@ Type "/help"
 Enter
 Sleep 1.4s
 
-Type "/backend"
+Type "/provider"
 Enter
 Sleep 1.4s
 Type "q"


### PR DESCRIPTION
Follow-up to #41.

Updates the VHS demo tape to use the current `/provider` command instead of the compatibility alias `/backend`, so regenerated README media reflects the current Albatross v2.3.0 UX.

Checks: `git diff --check`